### PR TITLE
accurate emu timing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VENV ?= ENV
+.PHONY: default cm2350_tests
 
 .PHONY: all virtualenv venv tests
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: tests
 virtualenv venv: $(VENV)
 
 $(VENV):
-	virtualenv --python=python3 $(VENV)
+	#virtualenv --python=python3 $(VENV)
 	. $(VENV)/bin/activate && pip install -r requirements.txt
 
 tests: $(VENV)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
-.PHONY: default cm2350_tests
+VENV ?= ENV
 
-.PHONY: all virtualenv venv tests
+.PHONY: all tests
 
 all: tests
 
-virtualenv venv: $(VENV)
-
 $(VENV):
-	#virtualenv --python=python3 $(VENV)
+	virtualenv --python=python3 $(VENV)
 	. $(VENV)/bin/activate && pip install -r requirements.txt
 
 tests: $(VENV)

--- a/cm2350/__init__.py
+++ b/cm2350/__init__.py
@@ -43,30 +43,6 @@ class CM2350:
                 },
             }
         },
-
-        # Standard vivisect emulator settings that need to be different for the
-        # target platform. Usually the project-specific values will be used but
-        # if the vivisect loader-specific options are used we want them to be
-        # correct.
-        'viv': {
-            'parsers': {
-                'blob': {
-                    'arch': 'ppc32-embedded',
-                    'bigend': True,
-                    'baseaddr': 0,
-                },
-                'ihex': {
-                    'arch': 'ppc32-embedded',
-                    'bigend': True,
-                    'offset': 0,
-                },
-                'srec': {
-                    'arch': 'ppc32-embedded',
-                    'bigend': True,
-                    'offset': 0,
-                }
-            }
-        }
     }
 
     docconfig = {

--- a/cm2350/__init__.py
+++ b/cm2350/__init__.py
@@ -1,7 +1,4 @@
 # the core of the CM2350 simulator
-import os
-import sys
-import time
 
 import vivisect.cli as v_cli
 import envi.archs.ppc.emu as eape

--- a/cm2350/clocks.py
+++ b/cm2350/clocks.py
@@ -1,0 +1,14 @@
+class EmuClocks:
+    '''
+    Provides a standardized way for peripherals to register core processor
+    clocks that can be used by other peripherals.
+    '''
+
+    def __init__(self):
+        self._system_clocks = {}
+
+    def registerClock(self, clock, func):
+        self._system_clocks[clock] = func
+
+    def getClock(self, clock):
+        return self._system_clocks[clock]()

--- a/cm2350/e200_gdb.py
+++ b/cm2350/e200_gdb.py
@@ -183,7 +183,7 @@ class e200GDB(vtp_gdb.GdbBaseEmuServer):
         resume, we put the Break instruction bytes back in.
         '''
         if not self._bps_in_place:
-            logger.debug('Installing breakpoints: ' + ','.join(hex(a) for a in self._bpdata))
+            logger.debug('Installing breakpoints: %r', self._bpdata)
             for va in self._bpdata:
                 self._installBreakpoint(va)
             self._bps_in_place = True
@@ -194,7 +194,7 @@ class e200GDB(vtp_gdb.GdbBaseEmuServer):
         resume, we put the Break instruction bytes back in.
         '''
         if self._bps_in_place:
-            logger.debug('Removing breakpoints: ' + ','.join(hex(a) for a in self._bpdata))
+            logger.debug('Removing breakpoints: %r', self._bpdata)
             for va in self._bpdata:
                 self._uninstallBreakpoint(va)
             self._bps_in_place = False
@@ -206,7 +206,7 @@ class e200GDB(vtp_gdb.GdbBaseEmuServer):
         if addr in self._bpdata:
             raise Exception('Cannot add breakpoint that already exists @ 0x%x' % addr)
 
-        logger.debug('Adding new breakpoint: 0x%x' % addr)
+        logger.debug('Adding new breakpoint: -1x%x', addr)
         origbytes = self._bpdata.get(addr)
         if origbytes:
             # Error, this breakpoint is already set
@@ -254,7 +254,7 @@ class e200GDB(vtp_gdb.GdbBaseEmuServer):
 
         # Only need to write the original data back to memory if the breakpoint 
         # is currently in memory.
-        logger.debug('Removing breakpoint: 0x%x' % addr)
+        logger.debug('Removing breakpoint: 0x%x', addr)
         if self._bps_in_place:
             self._uninstallBreakpoint(addr)
         del self._bpdata[addr]

--- a/cm2350/e200_gdb.py
+++ b/cm2350/e200_gdb.py
@@ -206,7 +206,7 @@ class e200GDB(vtp_gdb.GdbBaseEmuServer):
         if addr in self._bpdata:
             raise Exception('Cannot add breakpoint that already exists @ 0x%x' % addr)
 
-        logger.debug('Adding new breakpoint: -1x%x', addr)
+        logger.debug('Adding new breakpoint: 0x%x', addr)
         origbytes = self._bpdata.get(addr)
         if origbytes:
             # Error, this breakpoint is already set

--- a/cm2350/e200_intc.py
+++ b/cm2350/e200_intc.py
@@ -182,7 +182,7 @@ class e200INTC:
         newpc = self.getHandler(newexc)
 
         logger.debug('PC: 0x%08x (%r)  LVL: %d -> %d  NEWPC: 0x%08x',
-                self.emu.getProgramCounter(), newexc, self.curlvl, newexc.prio, newpc)
+                self.emu._cur_instr[2], newexc, self.curlvl, newexc.prio, newpc)
         self.emu.setProgramCounter(newpc)
 
         # change self.curlvl

--- a/cm2350/e200_intc.py
+++ b/cm2350/e200_intc.py
@@ -135,7 +135,12 @@ class e200INTC:
         # If this was a debug exception and the external debugger is connected 
         # it should have been handled through the external debugger by now, 
         # don't change the PC
-        if isinstance(newexc, intc_exc.DebugException) and \
+        #
+
+        if isinstance(newexc, intc_exc.ResetException):
+            raise newexc
+
+        elif isinstance(newexc, intc_exc.DebugException) and \
                 self.emu.gdbstub.isClientConnected():
             # Before halting re-evaluate if there are any pending interrupts. If 
             # a stepi happens it may be done from the GDB server thread in which 

--- a/cm2350/e200z7.py
+++ b/cm2350/e200z7.py
@@ -32,7 +32,7 @@ from envi.archs.ppc.regs import REG_MCSR, REG_MSR, REG_TSR, REG_TCR, REG_DEC, \
 from .ppc_vstructs import BitFieldSPR, v_const, v_w1c, v_bits
 
 # PPC Specific packages
-from . import emutimers, ppc_time, mmio, ppc_mmu, ppc_xbar, e200_intc, \
+from . import emutimers, clocks, ppc_time, mmio, ppc_mmu, ppc_xbar, e200_intc, \
         intc_exc, e200_gdb
 
 
@@ -115,7 +115,7 @@ import vivisect.impemu.emulator as vimp_emu
 
 class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
                  eape.Ppc32EmbeddedEmulator, ppc_time.PpcEmuTime,
-                 emutimers.ScaledEmuTimeCore):
+                 emutimers.ScaledEmuTimeCore, clocks.EmuClocks):
     def __init__(self, vw):
         # module registry
         self.modules = {}
@@ -141,6 +141,7 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
 
         ppc_time.PpcEmuTime.__init__(self)
         emutimers.ScaledEmuTimeCore.__init__(self, 0.1)
+        clocks.EmuClocks.__init__(self)
 
         # MCU timers
         self.mcu_wdt = None

--- a/cm2350/e200z7.py
+++ b/cm2350/e200z7.py
@@ -16,23 +16,21 @@ e200z7 is responsible for defining:
 '''
 import sys
 import queue
-import threading
-
 import logging
 logger = logging.getLogger(__name__)
 
+# Standard Vivisect/Envi packages
 import envi
 import envi.bits as e_bits
 import envi.memory as e_mem
+
+# PPC registers
 from envi.archs.ppc.regs import REG_MCSR, REG_MSR, REG_TSR, REG_TCR, REG_DEC, \
         REG_DECAR, REG_HID0, REG_HID1, REG_TBU, REG_TB, REG_TBU_WO, REG_TBL_WO
 from .ppc_vstructs import BitFieldSPR, v_const, v_w1c, v_bits
 
-from . import emutimers, mmio, ppc_mmu, e200_intc, e200_gdb
-from .const import *
-
-# PPC/MCU Exceptions
-from . import intc_exc, ppc_xbar
+# PPC Specific packages
+from . import emutimers, ppc_time, mmio, ppc_mmu, e200_intc, intc_const, e200_gdb
 
 
 __all__ = [
@@ -108,115 +106,13 @@ class MCSR(BitFieldSPR):
         self.flags = v_w1c(32)
 
 
-class PpcEmulationTime(emutimers.EmulationTime):
-    '''
-    PowerPC specific emulator time and timer handling.
-    '''
-    def __init__(self, systime_scaling=0.01):
-        super().__init__(systime_scaling)
-
-        # The time base can be written to which is supposed to reset the point
-        # that the system time is counting from.  We don't want to change the
-        # EmulationTime._sysoffset offset because that may impact the tracking
-        # of any timers currently running.  Instead use a timebase offset value
-        # so values read from TBU/TBL will have the correct values but the
-        # systicks() will be unmodified.
-        self._tb_offset = 0
-
-        # Register the TBU/TBL callbacks, these are read-only so no write
-        # callback is attached.
-        self.addSprReadHandler(REG_TB, self.tblRead)
-        self.addSprReadHandler(REG_TBU, self.tbuRead)
-        self.addSprWriteHandler(REG_TB, self._invalid_tb_write)
-        self.addSprWriteHandler(REG_TBU, self._invalid_tb_write)
-
-        # TODO: The TBU/TBL hypervisor access registers are write-only, but this
-        # is not yet implemented
-
-        # The TBU_WO/TBL_WO SPRs are used to hold the desired timebase offset
-        # value in them.  They are write-only so these callback functions ensure
-        # the reads are correctly emulated.
-        self.addSprReadHandler(REG_TBL_WO, self._invalid_tb_read)
-        self.addSprReadHandler(REG_TBU_WO, self._invalid_tb_read)
-        self.addSprWriteHandler(REG_TBL_WO, self.tblWrite)
-        self.addSprWriteHandler(REG_TBU_WO, self.tbuWrite)
-
-    def _invalid_tb_write(self, emu, op):
-        pass
-
-    def _invalid_tb_read(self, emu, op):
-        return 0
-
-    def tblRead(self, emu, op):
-        '''
-        Read callback handler to associate the value of the TBL SPR with the
-        EmulationTime.
-        '''
-        # In 64-bit mode reading the TBL returns the entire 64-bit TB value, in
-        # 32-bit mode its just the lower 32-bits, but this masking is done
-        # already in the PpcRegOper class (and will be set in the i_mfspr()
-        # handler that calls this)
-        return self.systicks()
-
-    def tbuRead(self, emu, op):
-        '''
-        Read callback handler to associate the value of the TBU SPR with the
-        EmulationTime.
-        '''
-        # Get the top 32-bits of the "ticks" value.  This should be only 32-bits
-        # wide regardless of if this is a 64-bit or 32-bit machine.
-        return (self.systicks() >> 32) & 0xFFFFFFFF
-
-    def tblWrite(self, emu, op):
-        '''
-        Update the tb_offset so TBL values returned from this point on
-        reflect the new offset.
-        '''
-        # Ensure that the offset value is only 32-bits wide regardless of the
-        # platform size.
-        tbl_offset = self.getOperValue(op, 1) & 0xFFFFFFFF
-
-        # Based on the new TBL offset and the current value of TBU_WO, calculate
-        # the new desired timebase offset
-        tbu_offset = emu.getRegister(REG_TBU_WO)
-        offset = (tbu_offset << 32) | tbl_offset
-        self._tb_offset = super().systicks() - offset
-
-        # Return the offset so that TBL_WO has the correct offset to use to
-        # calculate the desired timebase offset.
-        return tbl_offset
-
-    def tbuWrite(self, emu, op):
-        '''
-        Update the tb_offset so TBU values returned from this point on
-        reflect the new offset.
-        '''
-        # Ensure that the offset value is only 32-bits wide regardless of the
-        # platform size.
-        tbu_offset = self.getOperValue(op, 1) & 0xFFFFFFFF
-
-        # Based on the new TBU offset and the current value of TBL_WO, calculate
-        # the new desired timebase offset
-        tbl_offset = emu.getRegister(REG_TBL_WO)
-        offset = (tbu_offset << 32) | tbl_offset
-        self._tb_offset = super().systicks() - offset
-
-        # Return the offset so that TBU_WO has the correct offset to use to
-        # calculate the desired timebase offset.
-        return tbu_offset
-
-    def systicks(self):
-        '''
-        Because PowerPC allows writes to the "Write-Only" TBL/TBU registers,
-        adjust the returned systicks value by the current offset.
-        '''
-        return super().systicks() - self._tb_offset
-
-
 import envi.archs.ppc.emu as eape
-import vivisect.impemu.platarch.ppc as vimp_ppc_emu
-#class PPC_e200z7(mmio.ComplexMemoryMap, eape.Ppc32EmbeddedEmulator, PpcEmulationTime):
-class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.Ppc32EmbeddedEmulator, PpcEmulationTime):
+import vivisect.impemu.emulator as vimp_emu
+#import vivisect.impemu.platarch.ppc as vimp_ppc_emu
+
+class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
+                 eape.Ppc32EmbeddedEmulator, ppc_time.PpcEmuTime,
+                 emutimers.ScaledEmuTimeCore):
     def __init__(self, vw):
         # module registry
         self.modules = {}
@@ -237,13 +133,11 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.
         # class the PPC_e200z7 is designed so that the core vivisect workspace
         # emulator can be removed in the future to improve performance (at the
         # cost of analysis/inspection/live debug capabilities).
-        #
-        # TODO: CLI enabled logread/logwrite functionality?
-        #vimp_ppc_emu.PpcWorkspaceEmulator.__init__(self, vw, nostack=True, funconly=False, logread=True, logwrite=True)
-        vimp_ppc_emu.PpcWorkspaceEmulator.__init__(self, vw, nostack=True, funconly=False)
 
-        #PpcEmulationTime.__init__(self, 0.1)
-        PpcEmulationTime.__init__(self)
+        vimp_emu.WorkspaceEmulator.__init__(self, vw, nostack=True, funconly=False)
+
+        ppc_time.PpcEmuTime.__init__(self)
+        emutimers.ScaledEmuTimeCore.__init__(self, 0.1)
 
         # MCU timers
         self.mcu_wdt = None
@@ -431,7 +325,7 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.
 
     def _hid0TBUpdate(self, hid0):
         if self.hid0.tben:
-            self.enableTimebase()
+            self.resume_time()
 
             # When the timebase is enabled also check if the WDT, FIT or DEC
             # timers should be started
@@ -441,9 +335,8 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.
                 self._startMCUFIT()
             if self.tcr.die:
                 self._startMCUWDT()
-
         else:
-            self.disableTimebase()
+            self.halt_time()
 
             # If any of the timebase-run MCU timers are running, stop them now
             if self.tcr.wie:
@@ -733,6 +626,7 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.
             # do normal opcode parsing and execution
             pc = self.getProgramCounter()
             op = self.parseOpcode(pc)
+
             # TODO: check MSR for FP (MSR_FP_MASK) and SPE (MSR_SPE_MASK)
             # support here?
             self.executeOpcode(op)
@@ -753,6 +647,9 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.
             # this was a DNH instruction, pass control to the GDB stub.
             self.gdbstub.handleInterrupts(exc)
 
+            # Increment the tick counter
+            self.tick()
+
         except (envi.UnsupportedInstruction, envi.InvalidInstruction) as exc:
             logger.exception('Unsupported Instruction 0x%x', pc)
 
@@ -771,10 +668,8 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_ppc_emu.PpcWorkspaceEmulator, eape.
             self.queueException(exc)
 
     def run(self):
-        """
-        Faster tight loop of what the stepi() function does.
-        Make sure this stays in sync with stepi()!
-        """
+        # TODO: potentially slightly faster without calling a separate function,
+        # but keeping them in sync is difficult.
         while True:
             self.stepi()
 

--- a/cm2350/e200z7.py
+++ b/cm2350/e200z7.py
@@ -365,10 +365,16 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
         # for processing
         self.external_io = queue.Queue()
 
+        # reset the system emulation time, then init all modules
+        self.systimeReset()
+
         # initialize the various modules on this chip.
         for key, module in self.modules.items():
             logger.debug("init_core: Initializing %r...", key)
             module.init(self)
+
+        # Now start the system time
+        self.resume_time()
 
     def reset_core(self):
         '''
@@ -437,9 +443,124 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
         Handles the condition when a gdb client detaches. For now we will halt
         the emulator when this occurs.
         '''
+<<<<<<< HEAD
         self.queueException(intc_exc.GdbClientDetachEvent())
         self.resume_exec()
 
+||||||| parent of 14dc520 (saving progress, SWT tests don't all pass yet)
+        # if va is already a breakpoint, don't do it!!
+        if va in self._bpdata:
+            return -1   # raise exception
+
+        brkbytes = self.arch.archGetBreakInstr()
+
+        # check for overlapping breakpoints
+        for tva in range(va, va+len(brkbytes)-1):
+            if tva in self._bpdata:
+                return -2   # raise exception
+
+        for tva in range(va - len(brkbytes)+1, va):
+            if tva in self._bpdata:
+                return -3   # raise exception
+
+        # store existing bytes
+        self._bpdata[va] = self.readMemory(va, len(brkbyes))
+
+    def _putDownBreakpoints(self):
+        '''
+        At each emulator stop, we want to replace the original bytes.  On 
+        resume, we put the Break instruction bytes back in.
+        '''
+        brkbytes = self.arch.archGetBreakInstr()
+
+        for va in self._bpdata:
+            # stamp in a Break instruction
+            self.writeMemory(va, brkbytes)
+
+        self._bps_in_place = True
+
+    def _pullUpBreakpoints(self):
+        '''
+        At each emulator stop, we want to replace the original bytes.  On 
+        resume, we put the Break instruction bytes back in.
+        '''
+        brkbytes = self.arch.archGetBreakInstr()
+
+        for va, origbytes in list(self._bpdata.items()):
+            # restore the original bytes
+            self.writeMemory(va, origbytes)
+        
+        self._bps_in_place = False
+
+    def delBreakpoint(self, va):
+        '''
+        Remove breakpoint.
+        '''
+        if va not in self._bpdata:
+            return -1
+
+        origbytes = self._bpdata.pop(va)
+        if self._bps_in_place:
+            self.writeMemory(va, origbytes)
+
+
+=======
+        # if va is already a breakpoint, don't do it!!
+        if va in self._bpdata:
+            return -1   # raise exception
+
+        brkbytes = self.arch.archGetBreakInstr()
+
+        # check for overlapping breakpoints
+        for tva in range(va, va+len(brkbytes)-1):
+            if tva in self._bpdata:
+                return -2   # raise exception
+
+        for tva in range(va - len(brkbytes)+1, va):
+            if tva in self._bpdata:
+                return -3   # raise exception
+
+        # store existing bytes
+        self._bpdata[va] = self.readMemory(va, len(brkbyes))
+
+    def _putDownBreakpoints(self):
+        '''
+        At each emulator stop, we want to replace the original bytes.  On 
+        resume, we put the Break instruction bytes back in.
+        '''
+        brkbytes = self.arch.archGetBreakInstr()
+
+        for va in self._bpdata:
+            # stamp in a Break instruction
+            self.writeMemory(va, brkbytes)
+
+        self._bps_in_place = True
+
+    def _pullUpBreakpoints(self):
+        '''
+        At each emulator stop, we want to replace the original bytes.  On 
+        resume, we put the Break instruction bytes back in.
+        '''
+        brkbytes = self.arch.archGetBreakInstr()
+
+        for va, origbytes in list(self._bpdata.items()):
+            # restore the original bytes
+            self.writeMemory(va, origbytes)
+
+        self._bps_in_place = False
+
+    def delBreakpoint(self, va):
+        '''
+        Remove breakpoint.
+        '''
+        if va not in self._bpdata:
+            return -1
+
+        origbytes = self._bpdata.pop(va)
+        if self._bps_in_place:
+            self.writeMemory(va, origbytes)
+
+>>>>>>> 14dc520 (saving progress, SWT tests don't all pass yet)
     ###############################################################################
     # Redirect TLB instruction emulation functions to the MMU peripheral
     ###############################################################################

--- a/cm2350/e200z7.py
+++ b/cm2350/e200z7.py
@@ -115,8 +115,8 @@ import vivisect.impemu.emulator as vimp_emu
 
 class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
                  eape.Ppc32EmbeddedEmulator, ppc_time.PpcEmuTime,
-                 emutimers.ScaledEmuTimeCore, clocks.EmuClocks):
-                 #emutimers.EmuTimeCore, clocks.EmuClocks):
+                 #emutimers.ScaledEmuTimeCore, clocks.EmuClocks):
+                 emutimers.EmuTimeCore, clocks.EmuClocks):
     def __init__(self, vw):
         # module registry
         self.modules = {}
@@ -141,8 +141,8 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
         vimp_emu.WorkspaceEmulator.__init__(self, vw, nostack=True, funconly=False)
 
         ppc_time.PpcEmuTime.__init__(self)
-        emutimers.ScaledEmuTimeCore.__init__(self, 0.1)
-        #emutimers.EmuTimeCore.__init__(self)
+        #emutimers.ScaledEmuTimeCore.__init__(self, 0.1)
+        emutimers.EmuTimeCore.__init__(self)
         clocks.EmuClocks.__init__(self)
 
         # MCU timers

--- a/cm2350/e200z7.py
+++ b/cm2350/e200z7.py
@@ -116,6 +116,7 @@ import vivisect.impemu.emulator as vimp_emu
 class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
                  eape.Ppc32EmbeddedEmulator, ppc_time.PpcEmuTime,
                  emutimers.ScaledEmuTimeCore, clocks.EmuClocks):
+                 #emutimers.EmuTimeCore, clocks.EmuClocks):
     def __init__(self, vw):
         # module registry
         self.modules = {}
@@ -141,6 +142,7 @@ class PPC_e200z7(mmio.ComplexMemoryMap, vimp_emu.WorkspaceEmulator,
 
         ppc_time.PpcEmuTime.__init__(self)
         emutimers.ScaledEmuTimeCore.__init__(self, 0.1)
+        #emutimers.EmuTimeCore.__init__(self)
         clocks.EmuClocks.__init__(self)
 
         # MCU timers

--- a/cm2350/emutimers.py
+++ b/cm2350/emutimers.py
@@ -442,7 +442,7 @@ class ScaledEmuTimeCore(EmuTimeCore):
     def systimeReset(self):
         EmuTimeCore.systimeReset(self)
         self._sysoffset = time.time()
-        self._breakstart = _sysoffset
+        self._breakstart = self._sysoffset
         self.timerUpdated()
 
     def getSystemScaling(self):

--- a/cm2350/intc_const.py
+++ b/cm2350/intc_const.py
@@ -96,3 +96,15 @@ MCR_VTES_MASK   = 1 << MCR_VTES
 MMD_MCR = 0
 MMD_CPR = 2
 MMD_IACKR = 4
+
+
+class ResetSource(enum.Enum):
+    POWER_ON            = enum.auto()
+    EXTERNAL            = enum.auto()
+    SOFTWARE_SYSTEM     = enum.auto()
+    LOSS_OF_CLOCK       = enum.auto()
+    LOSS_OF_LOCK        = enum.auto()
+    CORE_WATCHDOG       = enum.auto()  # MCU watchdog
+    DEBUG               = enum.auto()
+    WATCHDOG            = enum.auto()  # SWT peripheral
+    SOFTWARE_EXTERNAL   = enum.auto()

--- a/cm2350/intc_exc.py
+++ b/cm2350/intc_exc.py
@@ -198,6 +198,12 @@ class ResetException(INTCException):
     __ivor__ = EXC_RESET
     __maskable__ = False
 
+    def __init__(self, source, *args, **kwargs):
+        # Reset exceptions must have a reset reason
+        self.source = source
+        super().__init__(*args, **kwargs)
+
+
 ### Base Exceptions (related to IVORs)
 class CriticalInputException(CriticalPrioException):
     __priority__ = INTC_LEVEL.CRITICAL_INPUT

--- a/cm2350/mpc5674.py
+++ b/cm2350/mpc5674.py
@@ -862,7 +862,7 @@ class MPC5674_Emulator(e200z7.PPC_e200z7, project.VivProject):
 
     def run(self):
         try:
-            logger.info('Starting execution @ 0x%x', self.getProgramCounter())
+            logger.info('Starting execution @ 0x%x', self._cur_instr[2])
 
             # If the --gdb-port flag was provided then we should wait for a GDB 
             # client to connect before continuing
@@ -872,7 +872,7 @@ class MPC5674_Emulator(e200z7.PPC_e200z7, project.VivProject):
             e200z7.PPC_e200z7.run(self)
         except KeyboardInterrupt:
             print()
-            logger.info('Execution stopped @ 0x%x', self.getProgramCounter())
+            logger.info('Execution stopped @ 0x%x', self._cur_instr[2])
 
 ### special register hardware interfacing
 # hook particular registers such that they don't store data, but rather interface to a virtual device

--- a/cm2350/mpc5674.py
+++ b/cm2350/mpc5674.py
@@ -607,7 +607,7 @@ class MPC5674_Emulator(e200z7.PPC_e200z7, project.VivProject):
         self.loadInitialFirmware()
 
         # Complete initialization of the e200z7 core
-        self.init_core()
+        self.init()
 
         # If the --gdb-port flag is provided 
 
@@ -789,8 +789,8 @@ class MPC5674_Emulator(e200z7.PPC_e200z7, project.VivProject):
                 addr + standby_size, addr + size)
         self.writeMemory(start, b'\x00' * (end - start))
 
-        # Reset the e200z7 core
-        self.reset_core()
+        # Reset the core
+        super().reset()
 
     def loadInitialFirmware(self):
         '''
@@ -846,7 +846,7 @@ class MPC5674_Emulator(e200z7.PPC_e200z7, project.VivProject):
         else:
             self.flash.load_complete()
 
-    def init_core(self):
+    def init(self):
         logger.info('INIT')
 
         # Create the initial RAM data (it isn't all cleared out during reset)
@@ -858,7 +858,8 @@ class MPC5674_Emulator(e200z7.PPC_e200z7, project.VivProject):
                 addr, addr + size)
         self.addMemoryMap(addr, e_mem.MM_RWX, 'SRAM', b'\x00' * size)
 
-        e200z7.PPC_e200z7.init_core(self)
+        # Init the core
+        super().init()
 
     def run(self):
         try:

--- a/cm2350/peripherals/bam.py
+++ b/cm2350/peripherals/bam.py
@@ -147,6 +147,8 @@ class BAM(MMIOPeripheral):
         if self.analyze():
             logger.info("booting from first discovered boot entry: baseaddr: 0x%x  codeva: 0x%x", self.rchw_addr, self.rchw.entry_point)
             logger.debug(self.rchw.tree())
+        else:
+            logger.info("Using default boot entry of 0x%x", self.rchw.entry_point)
 
         # The default entry point if no BAM entry is found ix 0x00000000, which
         # is what the "invalid" RHCW will now indicate.

--- a/cm2350/peripherals/decfilt.py
+++ b/cm2350/peripherals/decfilt.py
@@ -1,6 +1,5 @@
 from ..ppc_vstructs import *
 from ..ppc_peripherals import *
-from ..intc_exc import ResetException
 
 import logging
 logger = logging.getLogger(__name__)

--- a/cm2350/peripherals/etpu2.py
+++ b/cm2350/peripherals/etpu2.py
@@ -65,32 +65,38 @@ class eTPU2(MMIOPeripheral):
     """
     def _param_ram_read(self, va, offset, size):
         value = self.param_ram[offset:offset+size]
-        logger.debug("0x%x:  eTPU2 ParamRAM read  [%x:%r] (%r)", self.emu.getProgramCounter(), va, size, value)
+        logger.debug("0x%x:  eTPU2 ParamRAM read  [%x:%r] (%r)",
+                     self.emu._cur_instr[2], va, size, value)
         return value
 
     def _param_ram_write(self, va, offset, bytez):
-        logger.debug("0x%x:  eTPU2 ParamRAM write [%x] = %r", self.emu.getProgramCounter(), va, bytez)
+        logger.debug("0x%x:  eTPU2 ParamRAM write [%x] = %r",
+                     self.emu._cur_instr[2], va, bytez)
         self.param_ram[offset:offset+len(bytez)] = bytez
 
     def _param_ram_mirror_read(self, va, offset, size):
         value = self.param_ram[offset:offset+size]
-        logger.debug("0x%x:  eTPU2 ParamRAMMirror read  [%x:%r] (%r)", self.emu.getProgramCounter(), va, size, value)
+        logger.debug("0x%x:  eTPU2 ParamRAMMirror read  [%x:%r] (%r)",
+                     self.emu._cur_instr[2], va, size, value)
         return value
 
     def _param_ram_bytes(self, va, offset, bytez):
         return self.param_ram
 
     def _param_ram_mirror_write(self, va, offset, bytez):
-        logger.debug("0x%x:  eTPU2 ParamRAMMirror write [%x] = %r", self.emu.getProgramCounter(), va, bytez)
+        logger.debug("0x%x:  eTPU2 ParamRAMMirror write [%x] = %r",
+                     self.emu._cur_instr[2], va, bytez)
         self.param_ram[offset:offset+len(bytez)] = bytez
 
     def _code_ram_read(self, va, offset, size):
         value = self.code_ram[offset:offset+size]
-        logger.debug("0x%x:  eTPU2 CodeRAM read  [%x:%r] (%r)", self.emu.getProgramCounter(), va, size, value)
+        logger.debug("0x%x:  eTPU2 CodeRAM read  [%x:%r] (%r)",
+                    self.emu._cur_instr[2], va, size, value)
         return value
 
     def _code_ram_write(self, va, offset, bytez):
-        logger.debug("0x%x:  eTPU2 CodeRAM write [%x] = %r", self.emu.getProgramCounter(), va, bytez)
+        logger.debug("0x%x:  eTPU2 CodeRAM write [%x] = %r",
+                     self.emu._cur_instr[2], va, bytez)
         self.code_ram[offset:offset+len(bytez)] = bytez
 
     def _code_ram_bytes(self, va, offset, bytez):

--- a/cm2350/peripherals/flexcan.py
+++ b/cm2350/peripherals/flexcan.py
@@ -1358,9 +1358,9 @@ class FlexCAN(ExternalIOPeripheral):
 
         # source clock = CPI source clock / (PRESDIV + 1)
         if ctrl.clk_src:
-            sclk = self.emu.siu.f_periph() / (ctrl.presdiv + 1)
+            sclk = self.emu.getClock('periph') / (ctrl.presdiv + 1)
         else:
-            sclk = self.emu.fmpll.f_extal() / (ctrl.presdiv + 1)
+            sclk = self.emu.getClock('extal') / (ctrl.presdiv + 1)
 
         # SYNC (1) + PROPSEG (0-7 + 1) + SEG1 (0-7 + 1) + SEG2 (0-7 + 1)
         tq_per_bit = ctrl.propseg + ctrl.pseg1 + ctrl.pseg2 + 4

--- a/cm2350/peripherals/flexcan.py
+++ b/cm2350/peripherals/flexcan.py
@@ -573,7 +573,7 @@ class FlexCAN(ExternalIOPeripheral):
                 isrflags=FLEXCAN_INT_FLAG_REGS,
                 isrevents=FLEXCAN_INT_EVENTS)
         # timer register
-        self._timer = TimerRegister(16)
+        self._timer = TimerRegister(emu=emu, bits=16)
 
         self.mode = None
         self.speed = None
@@ -1368,4 +1368,4 @@ class FlexCAN(ExternalIOPeripheral):
         self.speed = sclk / tq_per_bit
 
         # Set the timer register to run at the bus bit clock
-        self._timer.setFreq(self.emu, self.speed)
+        self._timer.setFreq(self.speed)

--- a/cm2350/peripherals/flexcan.py
+++ b/cm2350/peripherals/flexcan.py
@@ -941,7 +941,6 @@ class FlexCAN(ExternalIOPeripheral):
             # Set the code to indicate that a message has been received (this
             # isn't done for the RxFIFO received messages)
             msg.into_mb(self.registers.mb.value, offset=idx, code=FLEXCAN_CODE_RX_FULL, timestamp=self._timer.get())
-
             self.event('msg', mb, FLEXCAN_IFLAG2_MASK[mb])
 
     def normalTx(self, mb):

--- a/cm2350/peripherals/fmpll.py
+++ b/cm2350/peripherals/fmpll.py
@@ -93,6 +93,13 @@ class FMPLL(MMIOPeripheral):
         self.registers.vsAddParseCallback('esyncr1', self.esyncr1Update)
         self.registers.vsAddParseCallback('esyncr2', self.esyncr2Update)
 
+    def init(self, emu):
+        super().init(emu)
+
+        # Register the system clocks
+        emu.registerClock('pll',   self.f_pll)
+        emu.registerClock('extal', self.f_extal)
+
     def reset(self, emu):
         """
         Return the FMPLL peripheral to a reset state

--- a/cm2350/peripherals/siu.py
+++ b/cm2350/peripherals/siu.py
@@ -1,6 +1,6 @@
 from ..ppc_vstructs import *
 from ..ppc_peripherals import *
-from ..intc_exc import ResetException
+from ..intc_exc import ResetException, ResetSource
 
 import logging
 logger = logging.getLogger(__name__)
@@ -25,13 +25,6 @@ class SIU_MIDR(ReadOnlyRegister):
 
 
 class SIU_RSR(PeriphRegister):
-    # TODO: SYSTEM_RESET reasons should eventually be linked to the e200z7
-    # setException API.
-    #
-    # TODO: there are various fields in this register that appear to be
-    # read-only (like the PORS field) but may need to be able to be changed to
-    # reflect system reset information. For now set these bits as
-    # const/read-only
     def __init__(self, wkpcfg, bootcfg):
         super().__init__()
         self.pors = v_const(1)
@@ -52,7 +45,6 @@ class SIU_RSR(PeriphRegister):
 
 
 class SIU_SRCR(PeriphRegister):  # System Reset Control Register...
-    # TODO: might need to hook this one with some special logic
     def __init__(self):
         super().__init__()
         self.ssr = v_bits(1)
@@ -417,8 +409,74 @@ class SIU_REGISTERS(PeripheralRegisterSet):
     def __init__(self, wkpcfg, bootcfg):
         super().__init__()
 
-        #############################################
+        # Set PCR defaults
 
+        self._init_pcr_defaults(wkpcfg)
+
+        # Registers
+
+        self.midr    = (0x0004, SIU_MIDR())
+        self.rsr     = (0x000C, SIU_RSR(wkpcfg, bootcfg))
+        self.srcr    = (0x0010, SIU_SRCR())
+        self.eisr    = (0x0014, SIU_EISR())
+        self.direr   = (0x0018, SIU_DIRER())
+        self.dirsr   = (0x001C, SIU_DIRSR())
+        self.osr     = (0x0020, SIU_OSR())
+        self.orer    = (0x0024, SIU_ORER())
+        self.ireer   = (0x0028, SIU_IREER())
+        self.ifeer   = (0x002C, SIU_IFEER())
+        self.idfr    = (0x0030, SIU_IDFR())
+        self.ifir    = (0x0034, SIU_IFIR())
+
+        # PCR (Pin Control Registers)
+        # PCR registers must be initialized using the PCR_DEFAULT values because
+        # not all PCR fields can be modified for all pins.
+        self.pcr     = (0x0040, VTuple([SIU_PCRn() if c is None else SIU_PCRn(**c) for c in self._pcr_defaults]))
+
+        # Legacy GPDO
+        self.gpdo    = (0x0600, VTuple([SIU_GPDOn() for i in range(NUM_GPDIO_PINS)]))
+
+        # Legacy GPDI (only first 256 pins)
+        self.gpdi    = (0x0800, VTuple([SIU_GPDIn() for i in range(NUM_GPDIO_PINS // 2)]))
+
+        self.eiisr   = (0x0904, SIU_EIISR())
+        self.disr    = (0x0908, SIU_DISR())
+        self.isel4   = (0x0910, SIU_ISEL4())
+        self.isel5   = (0x0914, SIU_ISEL5())
+        self.isel6   = (0x0918, SIU_ISEL6())
+        self.isel7   = (0x091C, SIU_ISEL7())
+        self.isel8   = (0x0920, SIU_ISEL8())
+        self.isel9   = (0x0924, SIU_ISEL9())
+        self.decfil1 = (0x0928, SIU_DECFIL())
+        self.decfil2 = (0x092C, SIU_DECFIL())
+        self.ccr     = (0x0980, SIU_CCR())
+        self.eccr    = (0x0984, SIU_ECCR())
+        self.cbrh    = (0x0990, SIU_CBRH())
+        self.cbrl    = (0x0994, SIU_CBRL())
+        self.sysdiv  = (0x09A0, SIU_SYSDIV())
+        self.hlt     = (0x09A4, SIU_HLT())
+        self.hltack  = (0x09A8, SIU_HLTACK())
+
+        # Parallel GPDO
+        # 4 bytes for every 32 pins
+        self.pgpdo   = (0x0C00, VTuple([SIU_PGPDOn() for i in range(NUM_GPDIO_PINS // 32)]))
+
+        # Parallel GPDI
+        # 4 bytes for every 32 pins
+        self.pgpdi   = (0x0C40, VTuple([SIU_PGPDIn() for i in range(NUM_GPDIO_PINS // 32)]))
+
+        # Masked Parallel GPDO
+        # 2 bytes of mask and 2 bytes of data for every 16 pins
+        self.mpgpdo  = (0x0C80, VTuple([SIU_MPGPDOn() for i in range(NUM_GPDIO_PINS // 16)]))
+
+        # 0x0D00-0x0E00 is unimplemented (related to DSPI or eTPU functionality)
+        # 0x100 * 8 bits = size of the placeholder
+        self.tbd     = (0x0D00, VTuple([PlaceholderRegister(8) for i in range(0x100)]))
+
+        # Legacy GPDI (full range)
+        self.gpdi_full = (0x0E00, VTuple([SIU_GPDIn() for i in range(NUM_GPDIO_PINS)]))
+
+    def _init_pcr_defaults(self, wkpcfg):
         # There are 512 PCR registers but not all of them are valid, initialize
         # the PCR configurations with all fields set to None.
         #
@@ -484,85 +542,6 @@ class SIU_REGISTERS(PeripheralRegisterSet):
         self._pcr_defaults[440] = {'pa': 0,    'obe': 0,    'ibe': 0,    'dsc': None, 'ode': 0,    'hys': 0,    'src': 0,    'wpe': 1,    'wps': 1}
         for pin in range(441, 472):
             self._pcr_defaults[pin] = {'pa': 0,    'obe': 0,    'ibe': 0,    'dsc': None, 'ode': 0,    'hys': 0,    'src': 0,    'wpe': 1,    'wps': wkpcfg}
-
-        #############################################
-
-        # Registers
-
-        self.midr    = (0x0004, SIU_MIDR())
-        self.rsr     = (0x000C, SIU_RSR(wkpcfg, bootcfg))
-        self.srcr    = (0x0010, SIU_SRCR())
-        self.eisr    = (0x0014, SIU_EISR())
-        self.direr   = (0x0018, SIU_DIRER())
-        self.dirsr   = (0x001C, SIU_DIRSR())
-        self.osr     = (0x0020, SIU_OSR())
-        self.orer    = (0x0024, SIU_ORER())
-        self.ireer   = (0x0028, SIU_IREER())
-        self.ifeer   = (0x002C, SIU_IFEER())
-        self.idfr    = (0x0030, SIU_IDFR())
-        self.ifir    = (0x0034, SIU_IFIR())
-
-
-        # PCR (Pin Control Registers)
-        # PCR registers must be initialized using the PCR_DEFAULT values because
-        # not all PCR fields can be modified for all pins.
-        self.pcr     = (0x0040, VTuple([SIU_PCRn() if c is None else SIU_PCRn(**c) for c in self._pcr_defaults]))
-
-        # Legacy GPDO
-        self.gpdo    = (0x0600, VTuple([SIU_GPDOn() for i in range(NUM_GPDIO_PINS)]))
-
-        # Legacy GPDI (only first 256 pins)
-        self.gpdi    = (0x0800, VTuple([SIU_GPDIn() for i in range(NUM_GPDIO_PINS // 2)]))
-
-        self.eiisr   = (0x0904, SIU_EIISR())
-        self.disr    = (0x0908, SIU_DISR())
-        self.isel4   = (0x0910, SIU_ISEL4())
-        self.isel5   = (0x0914, SIU_ISEL5())
-        self.isel6   = (0x0918, SIU_ISEL6())
-        self.isel7   = (0x091C, SIU_ISEL7())
-        self.isel8   = (0x0920, SIU_ISEL8())
-        self.isel9   = (0x0924, SIU_ISEL9())
-        self.decfil1 = (0x0928, SIU_DECFIL())
-        self.decfil2 = (0x092C, SIU_DECFIL())
-        self.ccr     = (0x0980, SIU_CCR())
-        self.eccr    = (0x0984, SIU_ECCR())
-        self.cbrh    = (0x0990, SIU_CBRH())
-        self.cbrl    = (0x0994, SIU_CBRL())
-        self.sysdiv  = (0x09A0, SIU_SYSDIV())
-        self.hlt     = (0x09A4, SIU_HLT())
-        self.hltack  = (0x09A8, SIU_HLTACK())
-
-        # Parallel GPDO
-        # 4 bytes for every 32 pins
-        self.pgpdo   = (0x0C00, VTuple([SIU_PGPDOn() for i in range(NUM_GPDIO_PINS // 32)]))
-
-        # Parallel GPDI
-        # 4 bytes for every 32 pins
-        self.pgpdi   = (0x0C40, VTuple([SIU_PGPDIn() for i in range(NUM_GPDIO_PINS // 32)]))
-
-        # Masked Parallel GPDO
-        # 2 bytes of mask and 2 bytes of data for every 16 pins
-        self.mpgpdo  = (0x0C80, VTuple([SIU_MPGPDOn() for i in range(NUM_GPDIO_PINS // 16)]))
-
-        # 0x0D00-0x0E00 is unimplemented (related to DSPI or eTPU functionality)
-        # 0x100 * 8 bits = size of the placeholder
-        self.tbd     = (0x0D00, VTuple([PlaceholderRegister(8) for i in range(0x100)]))
-
-        # Legacy GPDI (full range)
-        self.gpdi_full = (0x0E00, VTuple([SIU_GPDIn() for i in range(NUM_GPDIO_PINS)]))
-
-    def reset(self, emu):
-        # TODO: Will probably need to set some other register values based on
-        # the reset reason, like watchdog and such
-
-        # Read the current state of SRCR[SER]
-        ser_value = self.srcr.ser
-
-        super().reset(emu)
-
-        # Change the default value of the RSR[SERF] flag to indicate if a reset
-        # has happened because the SRCR[SER] bit was set or not
-        self.rsr.vsOverrideValue('serf', ser_value)
 
 
 # Cache the byte offset, bit offset, and pin mask values for each pin.
@@ -728,12 +707,20 @@ class SIU(MMIOPeripheral):
         self.registers.pgpdo.vsAddParseCallback('by_idx', self.pgpdoUpdate)
         self.registers.mpgpdo.vsAddParseCallback('by_idx', self.mpgpdoUpdate)
 
+    def init(self, emu):
+        super().init(emu)
+
     def reset(self, emu):
         """
         Return the SIU peripheral to a reset state
         """
         # Reset the peripheral registers
         super().reset(emu)
+
+        # Indicate this is the initial power on reset, if this happened because 
+        # of a ResetException the handler in the CPU core will set a more 
+        # accurate reason.
+        self.registers.rsr.vsOverrideValue('pors', 1)
 
         # Set the system frequency now based on the default register values.
         self.updateSystemFreq()
@@ -754,6 +741,28 @@ class SIU(MMIOPeripheral):
         for idx in range(NUM_GPDIO_PINS // 32):
             self.refreshBlockValue(idx)
 
+    def setResetSource(self, source):
+        # First clear out any currently set reset sources
+        self.registers.rsr.reset(self.emu)
+        if source == ResetSource.POWER_ON:
+            self.registers.rsr.vsOverrideValue('pors', 1)
+        elif source == ResetSource.EXTERNAL:
+            self.registers.rsr.vsOverrideValue('ers', 1)
+        elif source == ResetSource.SOFTWARE_SYSTEM:
+            self.registers.rsr.vsOverrideValue('ssrs', 1)
+        elif source == ResetSource.LOSS_OF_CLOCK:
+            self.registers.rsr.vsOverrideValue('lcrs', 1)
+        elif source == ResetSource.LOSS_OF_LOCK:
+            self.registers.rsr.vsOverrideValue('llrs', 1)
+        elif source == ResetSource.CORE_WATCHDOG:
+            self.registers.rsr.vsOverrideValue('wdrs', 1)
+        elif source == ResetSource.DEBUG:
+            self.registers.rsr.vsOverrideValue('wdrs', 1)
+        elif source == ResetSource.WATCHDOG:
+            self.registers.rsr.vsOverrideValue('swtrs', 1)
+        elif source == ResetSource.SOFTWARE_EXTERNAL:
+            self.registers.rsr.vsOverrideValue('serf', 1)
+
     def checkCBRMatch(self, thing):
         # TODO: Eventually this should be compared against the password values
         # in shadow flash
@@ -763,8 +772,11 @@ class SIU(MMIOPeripheral):
             self.registers.ccr.vsOverrideValue('match', 0)
 
     def srcrUpdate(self, thing):
-        if self.registers.srcr.ser or self.registers.srcr.ssr:
-            raise ResetException()
+        if self.registers.srcr.ser:
+            self.emu.queueException(ResetException(ResetSource.SOFTWARE_EXTERNAL))
+
+        elif self.registers.srcr.ssr:
+            self.emu.queueException(ResetException(ResetSource.SOFTWARE_SYSTEM))
 
     def updateSystemFreq(self, thing=None):
         logger.debug('SIU: Setting system clock to %f MHz', self.f_cpu() / 1000000)

--- a/cm2350/peripherals/swt.py
+++ b/cm2350/peripherals/swt.py
@@ -285,12 +285,10 @@ class SWT(MMIOPeripheral):
         self.updateServiceKeys()
 
         with self._wdogHandlerLock:
-            csl = self.registers.mcr.csl
-
-        if csl:
-            freq = self.emu.fmpll.extal
-        else:
-            freq = self.emu.siu.f_periph()
+            if self.registers.mcr.csl:
+                freq = self.emu.getClock('extal')
+            else:
+                freq = self.emu.getClock('periph')
 
         # The SWT duration should be the value of TO (or 0x100 if TO is smaller)
         ticks = max(self.registers.to.wto, 0x100)

--- a/cm2350/peripherals/swt.py
+++ b/cm2350/peripherals/swt.py
@@ -295,9 +295,8 @@ class SWT(MMIOPeripheral):
             freq = self.emu.siu.f_periph()
 
         # The SWT duration should be the value of TO (or 0x100 if TO is smaller)
-        period = max(self.registers.to.wto, 0x100)
-
-        self.watchdog.start(freq, period)
+        ticks = max(self.registers.to.wto, 0x100)
+        self.watchdog.start(freq=freq, ticks=ticks)
 
     def stopWatchdog(self):
         self.watchdog.stop()

--- a/cm2350/ppc_peripherals.py
+++ b/cm2350/ppc_peripherals.py
@@ -81,9 +81,9 @@ class Peripheral:
     def init(self, emu):
         """
         Standard "module" peripheral init function. This is called only once
-        during emulator initialization when the emulator's init_core() function
-        is called. Any emulator-dependant initialization should be done in this
-        function and not in the constructor.
+        during emulator initialization when the emulator processor core's
+        init() function is called. Any emulator-dependant initialization should
+        be done in this function and not in the constructor.
 
         By default this function calls it's own reset() function at the end of
         this init() function. This should make it easy for a peripheral to
@@ -101,10 +101,10 @@ class Peripheral:
     def reset(self, emu):
         """
         Standard "module" peripheral reset function. This is called every time
-        the emulator's reset_core() function is called, and also by default by
-        this class's own init() function. This means that each peripheral only
-        needs to implement one function to initialize all values to the correct
-        default state.
+        the emulator processor core's reset() function is called, and also by
+        default by this class's own init() function. This means that each
+        peripheral only needs to implement one function to initialize all
+        values to the correct default state.
 
         This function is required to be implemented by all peripherals.
         """

--- a/cm2350/ppc_peripherals.py
+++ b/cm2350/ppc_peripherals.py
@@ -1193,8 +1193,11 @@ class ExternalIOClient:
         Closes the client connection
         """
         if self._sock is not None:
-            self._sock.shutdown(socket.SHUT_RDWR)
-            self._sock.close()
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+                self._sock.close()
+            except OSError:
+                pass
             self._sock = None
 
     def send(self, obj):

--- a/cm2350/ppc_peripherals.py
+++ b/cm2350/ppc_peripherals.py
@@ -10,6 +10,7 @@ import atexit
 import inspect
 
 import envi.bits as e_bits
+from envi.common import EMULOG
 
 from . import mmio
 from .ppc_vstructs import *
@@ -471,7 +472,8 @@ class MMIOPeripheral(Peripheral, mmio.MMIO_DEVICE):
 
         try:
             value = self._getPeriphReg(offset, size)
-            #logger.debug("0x%x:  %s: read  [%x:%r] (%r)", self.emu.getProgramCounter(), self.devname, va, size, value)
+            logger.log(EMULOG, "0x%x:  %s: read  [%x:%r] (%r)",
+                       self.emu._cur_instr[2], self.devname, va, size, value)
             return value
 
         except VStructUnimplementedError as exc:
@@ -523,7 +525,8 @@ class MMIOPeripheral(Peripheral, mmio.MMIO_DEVICE):
             # TODO: this seems inefficient, but should be good enough for now
             return self._slow_mmio_write(va, offset, data)
 
-        #logger.debug("0x%x:  %s: write [%x] = %r", self.emu.getProgramCounter(), self.devname, va, data)
+        logger.log(EMULOG, "0x%x:  %s: write [%x] = %r",
+                   self.emu._cur_instr[2], self.devname, va, data)
         try:
             self._setPeriphReg(offset, data)
 

--- a/cm2350/ppc_time.py
+++ b/cm2350/ppc_time.py
@@ -1,0 +1,110 @@
+from . import emutimers
+from envi.archs.ppc.regs import REG_TBU, REG_TB, REG_TBU_WO, REG_TBL_WO
+
+
+__all__ = [
+    'PpcEmuTime',
+]
+
+
+class PpcEmuTime:
+    '''
+    PowerPC specific emulator time and timer handling mixin
+    '''
+    def __init__(self):
+        # The time base can be written to which is supposed to reset the point
+        # that the system time is counting from.  We don't want to change the
+        # EmulationTime._sysoffset offset because that may impact the tracking
+        # of any timers currently running.  Instead use a timebase offset value
+        # so values read from TBU/TBL will have the correct values but the
+        # systicks() will be unmodified.
+        self._tb_offset = 0
+
+        # Register the TBU/TBL callbacks, these are read-only so no write
+        # callback is attached.
+        self.addSprReadHandler(REG_TB, self.tblRead)
+        self.addSprReadHandler(REG_TBU, self.tbuRead)
+        self.addSprWriteHandler(REG_TB, self._invalid_tb_write)
+        self.addSprWriteHandler(REG_TBU, self._invalid_tb_write)
+
+        # TODO: The TBU/TBL hypervisor access registers are write-only, but this
+        # is not yet implemented
+
+        # The TBU_WO/TBL_WO SPRs are used to hold the desired timebase offset
+        # value in them.  They are write-only so these callback functions ensure
+        # the reads are correctly emulated.
+        self.addSprReadHandler(REG_TBL_WO, self._invalid_tb_read)
+        self.addSprReadHandler(REG_TBU_WO, self._invalid_tb_read)
+        self.addSprWriteHandler(REG_TBL_WO, self.tblWrite)
+        self.addSprWriteHandler(REG_TBU_WO, self.tbuWrite)
+
+    def _invalid_tb_write(self, emu, op):
+        pass
+
+    def _invalid_tb_read(self, emu, op):
+        return 0
+
+    def tblRead(self, emu, op):
+        '''
+        Read callback handler to associate the value of the TBL SPR with the
+        EmulationTime.
+        '''
+        # In 64-bit mode reading the TBL returns the entire 64-bit TB value, in
+        # 32-bit mode its just the lower 32-bits, but this masking is done
+        # already in the PpcRegOper class (and will be set in the i_mfspr()
+        # handler that calls this)
+        return self.systicks()
+
+    def tbuRead(self, emu, op):
+        '''
+        Read callback handler to associate the value of the TBU SPR with the
+        EmulationTime.
+        '''
+        # Get the top 32-bits of the "ticks" value.  This should be only 32-bits
+        # wide regardless of if this is a 64-bit or 32-bit machine.
+        return (self.systicks() >> 32) & 0xFFFFFFFF
+
+    def tblWrite(self, emu, op):
+        '''
+        Update the tb_offset so TBL values returned from this point on
+        reflect the new offset.
+        '''
+        # Ensure that the offset value is only 32-bits wide regardless of the
+        # platform size.
+        tbl_offset = self.getOperValue(op, 1) & 0xFFFFFFFF
+
+        # Based on the new TBL offset and the current value of TBU_WO, calculate
+        # the new desired timebase offset
+        tbu_offset = emu.getRegister(REG_TBU_WO)
+        offset = (tbu_offset << 32) | tbl_offset
+        self._tb_offset = self.systicks() - offset
+
+        # Return the offset so that TBL_WO has the correct offset to use to
+        # calculate the desired timebase offset.
+        return tbl_offset
+
+    def tbuWrite(self, emu, op):
+        '''
+        Update the tb_offset so TBU values returned from this point on
+        reflect the new offset.
+        '''
+        # Ensure that the offset value is only 32-bits wide regardless of the
+        # platform size.
+        tbu_offset = self.getOperValue(op, 1) & 0xFFFFFFFF
+
+        # Based on the new TBU offset and the current value of TBL_WO, calculate
+        # the new desired timebase offset
+        tbl_offset = emu.getRegister(REG_TBL_WO)
+        offset = (tbu_offset << 32) | tbl_offset
+        self._tb_offset = self.systicks() - offset
+
+        # Return the offset so that TBU_WO has the correct offset to use to
+        # calculate the desired timebase offset.
+        return tbu_offset
+
+    def systicks(self):
+        '''
+        Because PowerPC allows writes to the "Write-Only" TBL/TBU registers,
+        adjust the returned systicks value by the current offset.
+        '''
+        return super().systicks() - self._tb_offset

--- a/cm2350/ppc_vstructs.py
+++ b/cm2350/ppc_vstructs.py
@@ -1580,7 +1580,7 @@ class BitFieldSPR(PeriphRegister):
     def init(self, emu):
         """
         Emulator initializer function, all registered module init() functions
-        are called when the emulator's init_core() function is called.
+        are called when the emulator processor core's init() function is called.
         """
         emu.addSprReadHandler(self._reg, self.read)
         emu.addSprWriteHandler(self._reg, self.write)

--- a/cm2350/project.py
+++ b/cm2350/project.py
@@ -1,5 +1,4 @@
 import sys
-import time
 import logging
 import os.path
 import weakref

--- a/cm2350/tests/helpers.py
+++ b/cm2350/tests/helpers.py
@@ -88,7 +88,12 @@ class MPC5674_Test(unittest.TestCase):
         pending_excs = self._getPendingExceptions()
         for exc in pending_excs:
             print('Unhanded PPC Exception %s' % exc)
-        self.assertEqual(pending_excs, [])
+
+        # Only assert if the test is current succeeding, we don't want to 
+        # override the error of a failure, the success attribute isn't set yet, 
+        # instead look at the errors attribute.
+        if not self._outcome.errors:
+            self.assertEqual(pending_excs, [])
 
         # Clean up the resources
         self.ECU.shutdown()

--- a/cm2350/tests/helpers.py
+++ b/cm2350/tests/helpers.py
@@ -44,7 +44,6 @@ class MPC5674_Test(unittest.TestCase):
     def setUp(self):
         if os.environ.get('LOG_LEVEL', 'INFO') == 'DEBUG':
             e_common.initLogging(logger, logging.DEBUG)
-            #self.args.append('-vvv')
 
         if self._systime_scaling is None:
             self._systime_scaling = 0.1 if self.accurate_timing else 1.0
@@ -75,7 +74,8 @@ class MPC5674_Test(unittest.TestCase):
         self.emu.setRegister(eapr.REG_MSR, msr_val)
 
         # Enable the timebase (normally done by writing a value to HID0)
-        self.emu.enableTimebase(start_paused=self._start_timebase_paused)
+        if not self._start_timebase_paused:
+            self.emu.resume_time()
 
     def _getPendingExceptions(self):
         # Remove all the exceptions in the pending list

--- a/cm2350/tests/helpers.py
+++ b/cm2350/tests/helpers.py
@@ -38,26 +38,21 @@ class MPC5674_Test(unittest.TestCase):
 
     # When set to False automatically sets the following options:
     #   - _start_timebase_paused = False
-    #   - _systime_scaling = 1
     #   - _disable_gc = False
     #
     # When set to True automatically sets the following options:
     #   - _start_timebase_paused = True
-    #   - _systime_scaling = 0.1
     #   - _disable_gc = True
     #
     # If any of the specific performance settings are not None, the specific
     # performance setting will be used instead of the default.
     accurate_timing = False
-    _systime_scaling = None
     _start_timebase_paused = None
     _disable_gc = None
 
     def setUp(self):
         initLogging(logger)
 
-        if self._systime_scaling is None:
-            self._systime_scaling = 0.1 if self.accurate_timing else 1.0
         if self._start_timebase_paused is None:
             self._start_timebase_paused = True if self.accurate_timing else False
         if self._disable_gc is None:
@@ -66,9 +61,6 @@ class MPC5674_Test(unittest.TestCase):
         logger.debug('Creating CM2350 with args: %r', self.args)
         self.ECU = CM2350(self.args)
         self.emu = self.ECU.emu
-
-        # Set the emulator systime scaling
-        self.emu._systime_scaling = self._systime_scaling
 
         # Check if the garbage collector should be disabled for these tests
         if self._disable_gc:

--- a/cm2350/tests/helpers.py
+++ b/cm2350/tests/helpers.py
@@ -18,7 +18,19 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     'MPC5674_Test',
+    'initLogging',
 ]
+
+
+def initLogging(logobj):
+    log_lvl = os.environ.get('LOG_LEVEL')
+    if log_lvl:
+        if hasattr(logging, log_lvl):
+            e_common.initLogging(logobj, getattr(logging, log_lvl))
+        elif hasattr(e_common, log_lvl):
+            e_common.initLogging(logobj, getattr(e_common, log_lvl))
+        else:
+            raise Exception('Invalid log level: %s' % log_lvl)
 
 
 class MPC5674_Test(unittest.TestCase):
@@ -42,8 +54,7 @@ class MPC5674_Test(unittest.TestCase):
     _disable_gc = None
 
     def setUp(self):
-        if os.environ.get('LOG_LEVEL', 'INFO') == 'DEBUG':
-            e_common.initLogging(logger, logging.DEBUG)
+        initLogging(logger)
 
         if self._systime_scaling is None:
             self._systime_scaling = 0.1 if self.accurate_timing else 1.0
@@ -92,8 +103,7 @@ class MPC5674_Test(unittest.TestCase):
         # Only assert if the test is current succeeding, we don't want to 
         # override the error of a failure, the success attribute isn't set yet, 
         # instead look at the errors attribute.
-        if not self._outcome.errors:
-            self.assertEqual(pending_excs, [])
+        self.assertEqual(pending_excs, [])
 
         # Clean up the resources
         self.ECU.shutdown()

--- a/cm2350/tests/test_cm2350_cli.py
+++ b/cm2350/tests/test_cm2350_cli.py
@@ -2,6 +2,7 @@ import os
 import copy
 import glob
 import json
+import time
 import random
 import shutil
 import struct
@@ -192,7 +193,11 @@ DEFAULT_PROJECT_CONFIG['project'] = {
             'shadowBOffset': 0,
             'backup': 'backup.flash'
         },
-        'SRAM': {'addr': 1073741824, 'size': 262144},
+        'SRAM': {
+            'addr': 0x40000000,
+            'size': 0x40000,
+            'standby_size': 0x8000,
+        },
         'FlexCAN_A': {'host': None, 'port': None},
         'FlexCAN_B': {'host': None, 'port': None},
         'FlexCAN_C': {'host': None, 'port': None},
@@ -205,9 +210,6 @@ DEFAULT_PROJECT_CONFIG['project'] = {
         'eQADC_B': {'host': None, 'port': None},
     }
 }
-
-# Merge the CM2350 default config with the vivisect default config
-DEFAULT_PROJECT_CONFIG = dict_merge(vivisect.defconfig, CM2350_DEFAULT_CONFIG)
 
 
 def get_config(config, flash_cfg=None):
@@ -462,6 +464,9 @@ class CM2350_CLI(unittest.TestCase):
             backup_file = None
         else:
             backup_file = os.path.join(config, '%s.%s' % (BACKUP_FILENAME, hash_value.hex()))
+
+        # Slight delay
+        time.sleep(0.1)
 
         #############################
         # Start testing now

--- a/cm2350/tests/test_cm2350_cli.py
+++ b/cm2350/tests/test_cm2350_cli.py
@@ -2,7 +2,6 @@ import os
 import copy
 import glob
 import json
-import time
 import random
 import shutil
 import struct

--- a/cm2350/tests/test_cm2350_cli.py
+++ b/cm2350/tests/test_cm2350_cli.py
@@ -465,9 +465,6 @@ class CM2350_CLI(unittest.TestCase):
         else:
             backup_file = os.path.join(config, '%s.%s' % (BACKUP_FILENAME, hash_value.hex()))
 
-        # Slight delay
-        time.sleep(0.1)
-
         #############################
         # Start testing now
 

--- a/cm2350/tests/test_cm2350_cli.py
+++ b/cm2350/tests/test_cm2350_cli.py
@@ -171,60 +171,39 @@ def dict_merge(a, b):
 
 
 # Default project configuration using the DEFAULT_CONFIG path, so it has an
-# empty firmware configuration.
-CM2350_DEFAULT_CONFIG = {
-    'viv': {
-        'parsers': {
-            'blob': {
-                'arch': 'ppc32-embedded',
-                'bigend': True,
-                'baseaddr': 0,
-            },
-            'ihex': {
-                'arch': 'ppc32-embedded',
-                'bigend': True,
-                'offset': 0,
-            },
-            'srec': {
-                'arch': 'ppc32-embedded',
-                'bigend': True,
-                'offset': 0,
-            }
-        }
-    },
-
-    'project': {
-        'name': PROJECT_NAME,
-        'platform': 'CM2350',
-        'arch': 'ppc32-embedded',
-        'bigend': True,
-        'format': 'blob',
-        'CM2350': { 'p89': 1, 'p90': 0, 'p91': 1, 'p92': 0},
-        'MPC5674': {
-            'SIU': {'pllcfg': 5, 'bootcfg': 0, 'wkpcfg': 1},
-            'FMPLL': {'extal': 40000000},
-            'FLASH': {
-                'fwFilename': None,
-                'baseaddr': 0,
-                'shadowAFilename': None,
-                'shadowAOffset': 0,
-                'shadowBFilename': None,
-                'shadowBOffset': 0,
-                'backup': 'backup.flash'
-            },
-            'SRAM': {'addr': 1073741824, 'size': 262144, 'standby_size': 32768},
-            'FlexCAN_A': {'host': None, 'port': None},
-            'FlexCAN_B': {'host': None, 'port': None},
-            'FlexCAN_C': {'host': None, 'port': None},
-            'FlexCAN_D': {'host': None, 'port': None},
-            'DSPI_A': {'host': None, 'port': None},
-            'DSPI_B': {'host': None, 'port': None},
-            'DSPI_C': {'host': None, 'port': None},
-            'DSPI_D': {'host': None, 'port': None},
-            'eQADC_A': {'host': None, 'port': None},
-            'eQADC_B': {'host': None, 'port': None},
-        }
-    },
+# empty firmware configuration
+DEFAULT_PROJECT_CONFIG = vivisect.defconfig
+DEFAULT_PROJECT_CONFIG['project'] = {
+    'name': PROJECT_NAME,
+    'platform': 'CM2350',
+    'arch': 'ppc32-embedded',
+    'bigend': True,
+    'format': 'blob',
+    'CM2350': { 'p89': 1, 'p90': 0, 'p91': 1, 'p92': 0},
+    'MPC5674': {
+        'SIU': {'pllcfg': 5, 'bootcfg': 0, 'wkpcfg': 1},
+        'FMPLL': {'extal': 40000000},
+        'FLASH': {
+            'fwFilename': None,
+            'baseaddr': 0,
+            'shadowAFilename': None,
+            'shadowAOffset': 0,
+            'shadowBFilename': None,
+            'shadowBOffset': 0,
+            'backup': 'backup.flash'
+        },
+        'SRAM': {'addr': 1073741824, 'size': 262144},
+        'FlexCAN_A': {'host': None, 'port': None},
+        'FlexCAN_B': {'host': None, 'port': None},
+        'FlexCAN_C': {'host': None, 'port': None},
+        'FlexCAN_D': {'host': None, 'port': None},
+        'DSPI_A': {'host': None, 'port': None},
+        'DSPI_B': {'host': None, 'port': None},
+        'DSPI_C': {'host': None, 'port': None},
+        'DSPI_D': {'host': None, 'port': None},
+        'eQADC_A': {'host': None, 'port': None},
+        'eQADC_B': {'host': None, 'port': None},
+    }
 }
 
 # Merge the CM2350 default config with the vivisect default config

--- a/cm2350/tests/test_mpc5674_bam.py
+++ b/cm2350/tests/test_mpc5674_bam.py
@@ -53,13 +53,12 @@ class MPC5674_Flash_BAM(MPC5674_Test):
     def test_bam_find_rchw(self):
         self.emu.flash.data[0:8] = b'\x00\x5a\x00\x00\xaa\xaa\xaa\xaa'
 
-        # timebase is enabled by default by in the setUp() function
-        self.assertTrue(self.emu.systimeRunning())
+        # reset to cause standard BAM processing
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00000000)
@@ -76,7 +75,7 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
@@ -93,7 +92,7 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00010000)
@@ -110,7 +109,7 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x0001C000)
@@ -127,7 +126,7 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00020000)
@@ -144,7 +143,7 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00030000)
@@ -159,7 +158,7 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, None)
@@ -169,13 +168,12 @@ class MPC5674_Flash_BAM(MPC5674_Test):
     def test_bam_rchw_booke(self):
         self.emu.flash.data[0x4000:0x4008] = b'\x00\x5A\x00\x00\x40\x00\x00\x00'
 
-        # timebase is enabled by default by in the setUp() function
-        self.assertTrue(self.emu.systimeRunning())
+        # reset to cause standard BAM processing
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
@@ -203,13 +201,12 @@ class MPC5674_Flash_BAM(MPC5674_Test):
     def test_bam_rchw_vle(self):
         self.emu.flash.data[0x4000:0x4008] = b'\x01\x5A\x00\x00\x40\x00\x00\x00'
 
-        # timebase is enabled by default by in the setUp() function
-        self.assertTrue(self.emu.systimeRunning())
+        # reset to cause standard BAM processing
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
@@ -231,13 +228,12 @@ class MPC5674_Flash_BAM(MPC5674_Test):
     def test_bam_rchw_mcu_watchdog(self):
         self.emu.flash.data[0x4000:0x4008] = b'\x04\x5A\x00\x00\x40\x00\x00\x00'
 
-        # timebase is enabled by default by in the setUp() function
-        self.assertTrue(self.emu.systimeRunning())
+        # reset to cause standard BAM processing
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
@@ -259,13 +255,12 @@ class MPC5674_Flash_BAM(MPC5674_Test):
     def test_bam_rchw_swt(self):
         self.emu.flash.data[0x4000:0x4008] = b'\x08\x5A\x00\x00\x40\x00\x00\x00'
 
-        # timebase is enabled by default by in the setUp() function
-        self.assertTrue(self.emu.systimeRunning())
+        # reset to cause standard BAM processing
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
         self.assertFalse(self.emu.systimeRunning())
-        self.emu.enableTimebase()
+        self.emu.resume_time()
         self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)

--- a/cm2350/tests/test_mpc5674_bam.py
+++ b/cm2350/tests/test_mpc5674_bam.py
@@ -1,3 +1,5 @@
+import unittest
+
 from ..ppc_mmu import PpcTlbPageSize, PpcTlbFlags, PpcTlbPerm
 
 from .helpers import MPC5674_Test
@@ -10,17 +12,6 @@ BAM_RCHW_ADDRS = [
     0x0001C000,
     0x00020000,
     0x00030000,
-]
-
-# TODO: MCU Core Watchdog not tested because the e200z7 class does not yet
-# implement and start a watchdog.  Enable this test when the e200z7 class
-# implements the watchdog.
-BAM_RCHW_VALUES = [
-    0x005A,     # The basic RCHW with no flags set
-    0x015A,     # Target is VLE
-    0x025A,     # Port size (unused by emulation)
-    #0x045A,     # MCU Core Watchdog enabled on startup
-    0x085A,     # SWT Watchdog enabled on startup
 ]
 
 DEFAULT_BOOKE_TLB = (
@@ -40,6 +31,8 @@ DEFAULT_VLE_TLB = (
 )
 
 class MPC5674_Flash_BAM(MPC5674_Test):
+    _start_timebase_paused = True
+
     def test_bam_flash_empty(self):
         # Confirm that by default no valid target was found
         self.assertEqual(self.emu.bam.rchw_addr, None)
@@ -56,11 +49,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         # reset to cause standard BAM processing
         self.emu.reset()
 
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
-
         self.assertEqual(self.emu.bam.rchw_addr, 0x00000000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0xAAAAAAAA)
         self.assertEqual(self.emu.getProgramCounter(), 0xAAAAAAAA)
@@ -72,11 +60,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         self.emu.flash.data[0x4000:0x4008] = b'\x00\x5a\x00\x00\x20\x00\x00\x00'
 
         self.emu.reset()
-
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x20000000)
@@ -90,11 +73,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         self.emu.reset()
 
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
-
         self.assertEqual(self.emu.bam.rchw_addr, 0x00010000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
         self.assertEqual(self.emu.getProgramCounter(), 0x40000000)
@@ -106,11 +84,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         self.emu.flash.data[0x1C000:0x1C008] = b'\x00\x5a\x00\x00\x00\x12\x34\x56'
 
         self.emu.reset()
-
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x0001C000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x00123456)
@@ -124,11 +97,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         self.emu.reset()
 
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
-
         self.assertEqual(self.emu.bam.rchw_addr, 0x00020000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x00000000)
         self.assertEqual(self.emu.getProgramCounter(), 0x00000000)
@@ -141,11 +109,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         self.emu.reset()
 
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
-
         self.assertEqual(self.emu.bam.rchw_addr, 0x00030000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x00000010)
         self.assertEqual(self.emu.getProgramCounter(), 0x00000010)
@@ -156,11 +119,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         self.emu.reset()
 
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
-
         self.assertEqual(self.emu.bam.rchw_addr, None)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0)
         self.assertEqual(self.emu.getProgramCounter(), 0)
@@ -170,11 +128,6 @@ class MPC5674_Flash_BAM(MPC5674_Test):
 
         # reset to cause standard BAM processing
         self.emu.reset()
-
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
@@ -189,8 +142,8 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         # Ensure that the MPC4674F SWT is not running
         self.assertEqual(self.emu.swt.watchdog.running(), False)
 
-        # TODO: Ensure that the e200z7 MCU Watchdog is not running
-        #raise NotImplementedError('todo')
+        # Ensure that the e200z7 MCU Watchdog is not running
+        self.assertEqual(self.emu.mcu_wdt.running(), False)
 
         # TLB checking code borrowed from MMU/TLB tests
         for esel in range(len(DEFAULT_BOOKE_TLB)):
@@ -205,9 +158,9 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
+        self.assertFalse(self.emu.timebaseRunning())
+        self.emu.enableTimebase()
+        self.assertTrue(self.emu.timebaseRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
@@ -219,38 +172,17 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         self.assertEqual(self.emu.bam.rchw.ps0, 0)
         self.assertEqual(self.emu.bam.rchw.vle, 1)
 
+        # Ensure that the MPC4674F SWT is not running
+        self.assertEqual(self.emu.swt.watchdog.running(), False)
+
+        # Ensure that the e200z7 MCU Watchdog is not running
+        self.assertEqual(self.emu.mcu_wdt.running(), False)
+
         # TLB checking code borrowed from MMU/TLB tests
         for esel in range(len(DEFAULT_VLE_TLB)):
             for attr, val in DEFAULT_VLE_TLB[esel].items():
                 msg = 'tlb[%d].%s == 0x%x' % (esel, attr, val)
                 self.assertEqual(getattr(self.emu.mmu._tlb[esel], attr), val, msg)
-
-    def test_bam_rchw_mcu_watchdog(self):
-        self.emu.flash.data[0x4000:0x4008] = b'\x04\x5A\x00\x00\x40\x00\x00\x00'
-
-        # reset to cause standard BAM processing
-        self.emu.reset()
-
-        # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
-
-        self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
-        self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
-        self.assertEqual(self.emu.getProgramCounter(), 0x40000000)
-
-        self.assertEqual(self.emu.bam.rchw.rsvd, 0)
-        self.assertEqual(self.emu.bam.rchw.swt, 0)
-        self.assertEqual(self.emu.bam.rchw.wte, 1)
-        self.assertEqual(self.emu.bam.rchw.ps0, 0)
-        self.assertEqual(self.emu.bam.rchw.vle, 0)
-
-        # Ensure that the SWT watchdog is not running
-        self.assertEqual(self.emu.swt.watchdog.running(), False)
-
-        # TODO: Ensure that the e200z7 MCU Watchdog is not running
-        #raise NotImplementedError('todo')
 
     def test_bam_rchw_swt(self):
         self.emu.flash.data[0x4000:0x4008] = b'\x08\x5A\x00\x00\x40\x00\x00\x00'
@@ -259,9 +191,9 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         self.emu.reset()
 
         # System time should be disabled again after reset, re-enable it
-        self.assertFalse(self.emu.systimeRunning())
-        self.emu.resume_time()
-        self.assertTrue(self.emu.systimeRunning())
+        self.assertFalse(self.emu.timebaseRunning())
+        self.emu.enableTimebase()
+        self.assertTrue(self.emu.timebaseRunning())
 
         self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
         self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
@@ -276,5 +208,61 @@ class MPC5674_Flash_BAM(MPC5674_Test):
         # Ensure that the SWT watchdog is running
         self.assertEqual(self.emu.swt.watchdog.running(), True)
 
-        # TODO: Ensure that the e200z7 MCU Watchdog is running
-        #raise NotImplementedError('todo')
+        # Ensure that the e200z7 MCU Watchdog is running
+        self.assertEqual(self.emu.mcu_wdt.running(), False)
+
+    @unittest.skip('fix implementation of MCU WDT so it runs correctly')
+    def test_bam_rchw_mcu_wdt(self):
+        self.emu.flash.data[0x4000:0x4008] = b'\x04\x5A\x00\x00\x40\x00\x00\x00'
+
+        # reset to cause standard BAM processing
+        self.emu.reset()
+
+        # System time should be disabled again after reset, re-enable it
+        self.assertFalse(self.emu.timebaseRunning())
+        self.emu.enableTimebase()
+        self.assertTrue(self.emu.timebaseRunning())
+
+        self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
+        self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
+        self.assertEqual(self.emu.getProgramCounter(), 0x40000000)
+
+        self.assertEqual(self.emu.bam.rchw.rsvd, 0)
+        self.assertEqual(self.emu.bam.rchw.swt, 0)
+        self.assertEqual(self.emu.bam.rchw.wte, 1)
+        self.assertEqual(self.emu.bam.rchw.ps0, 0)
+        self.assertEqual(self.emu.bam.rchw.vle, 0)
+
+        # Ensure that the SWT watchdog is not running
+        self.assertEqual(self.emu.swt.watchdog.running(), False)
+
+        # Ensure that the e200z7 MCU Watchdog is running
+        self.assertEqual(self.emu.mcu_wdt.running(), True)
+
+    @unittest.skip('fix implementation of MCU WDT so it runs correctly')
+    def test_bam_rchw_swt_and_mcu_wdt(self):
+        self.emu.flash.data[0x4000:0x4008] = b'\x0C\x5A\x00\x00\x40\x00\x00\x00'
+
+        # reset to cause standard BAM processing
+        self.emu.reset()
+
+        # System time should be disabled again after reset, re-enable it
+        self.assertFalse(self.emu.timebaseRunning())
+        self.emu.enableTimebase()
+        self.assertTrue(self.emu.timebaseRunning())
+
+        self.assertEqual(self.emu.bam.rchw_addr, 0x00004000)
+        self.assertEqual(self.emu.bam.rchw.entry_point, 0x40000000)
+        self.assertEqual(self.emu.getProgramCounter(), 0x40000000)
+
+        self.assertEqual(self.emu.bam.rchw.rsvd, 0)
+        self.assertEqual(self.emu.bam.rchw.swt, 1)
+        self.assertEqual(self.emu.bam.rchw.wte, 1)
+        self.assertEqual(self.emu.bam.rchw.ps0, 0)
+        self.assertEqual(self.emu.bam.rchw.vle, 0)
+
+        # Ensure that the SWT watchdog is running
+        self.assertEqual(self.emu.swt.watchdog.running(), True)
+
+        # Ensure that the e200z7 MCU Watchdog is running
+        self.assertEqual(self.emu.mcu_wdt.running(), True)

--- a/cm2350/tests/test_mpc5674_edma.py
+++ b/cm2350/tests/test_mpc5674_edma.py
@@ -106,7 +106,7 @@ def get_xfer_vals(emu, saddr=None, ssize=None, daddr=None, dsize=None, nbytes=No
             if mstart + buffer > saddr:
                 start = saddr + buffer
                 stop = mstop
-            elif saddr + buffer > mstop:
+            elif saddr + buffer >= mstop:
                 start = mstart
                 stop = saddr - buffer
             else:

--- a/cm2350/tests/test_mpc5674_flexcan.py
+++ b/cm2350/tests/test_mpc5674_flexcan.py
@@ -207,7 +207,7 @@ def read_mb_data(emu, dev, mb):
 
 
 class MPC5674_FlexCAN_Test(MPC5674_Test):
-    _disable_gc = True
+    accurate_timing = True
 
     def set_sysclk_240mhz(self):
         # Default PLL clock based on the PCB params selected for these tests is
@@ -946,10 +946,10 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
                 else:
                     self.assertNotIn(mb, tx_mbs, msg=testmsg)
 
-            # It is expected that the calculated timestamp will be slightly
-            # larger than the actual timestamp because it is saved right
-            # after the memory write occurs that causes the transmit
-            margin = self.emu.can[dev].speed * 0.0200
+            # Unfortunately the IO thread has a pretty wide variation on when 
+            # things are received and processed so the margin has to be larger 
+            # for this test.
+            margin = self.emu.can[dev].speed * 0.0300
 
             # Confirm that the order of the generated interrupts matches both
             # the order of the transmitted messages and the interrupt source for
@@ -1354,6 +1354,8 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
 
 
 class MPC5674_FlexCAN_RealIO(MPC5674_Test):
+    accurate_timing = True
+
     args = [
         '-c',
         '-O', 'project.MPC5674.FlexCAN_A.port=10001',

--- a/cm2350/tests/test_mpc5674_flexcan.py
+++ b/cm2350/tests/test_mpc5674_flexcan.py
@@ -812,11 +812,10 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
 
             # Expected ticks (limit to 16 bits):
-            expected_val = int(self.emu.can[idx].speed * 0.5 * self.emu._systime_scaling) & 0xFFFF
+            expected_val = int(self.emu.can[idx].speed * 0.5) & 0xFFFF
 
-            # Margin of error is approximately 0.005 (so speed * 0.005 * system 
-            # scaling)
-            margin = self.emu.can[idx].speed * 0.005 * self.emu._systime_scaling
+            # Margin of error is approximately 0.005 (so speed * 0.005)
+            margin = self.emu.can[idx].speed * 0.005
 
             self.emu.writeMemValue(mcr_addr, 0, 4)
 
@@ -950,7 +949,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # It is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
-            margin = self.emu.can[dev].speed * 0.0200 * self.emu._systime_scaling
+            margin = self.emu.can[dev].speed * 0.0200
 
             # Confirm that the order of the generated interrupts matches both
             # the order of the transmitted messages and the interrupt source for
@@ -971,7 +970,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
 
                 # Confirm that the timestamp is accurate
                 tx_delay = tx_times[mb] - start_time
-                expected_ticks = int(self.emu.can[dev].speed * tx_delay * self.emu._systime_scaling) & 0xFFFF
+                expected_ticks = int(self.emu.can[dev].speed * tx_delay) & 0xFFFF
 
                 ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
                 timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
@@ -1087,7 +1086,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # It is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
-            margin = self.emu.can[dev].speed * 0.0050 * self.emu._systime_scaling
+            margin = self.emu.can[dev].speed * 0.0050
 
             # Zero out the timer register.
             self.emu.writeMemValue(timer_addr, 0, 4)
@@ -1105,7 +1104,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
                 # Confirm that the timestamp is accurate. The timer has probably
                 # wrapped by now so ensure it is limited to 16 bits
                 rx_delay = self.emu.systime() - start_time
-                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xFFFF
+                expected_ticks = int(self.emu.can[dev].speed * rx_delay) & 0xFFFF
 
                 ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
                 timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
@@ -1223,7 +1222,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # It is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
-            margin = self.emu.can[dev].speed * 0.0050 * self.emu._systime_scaling
+            margin = self.emu.can[dev].speed * 0.0050
 
             # The RxFIFO can hold 6 messages, each received message should
             # generate a RxFIFO Msg Available interrupt (MB5), when the last
@@ -1326,7 +1325,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             for i in range(len(msgs)):
                 testmsg = '%s RxFIFO[%d]' % (devname, i)
                 rx_delay = rx_times[i] - start_time
-                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xFFFF
+                expected_ticks = int(self.emu.can[dev].speed * rx_delay) & 0xFFFF
 
                 timestamp = struct.unpack_from('>H', rx_msgs[i], 2)[0]
                 self.assert_timer_within_range(timestamp, expected_ticks, margin, maxval=0xFFFF, msg=testmsg)
@@ -1355,9 +1354,6 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
 
 
 class MPC5674_FlexCAN_RealIO(MPC5674_Test):
-    #accurate_timing = True
-    #_systime_scaling = 0.01
-
     args = [
         '-c',
         '-O', 'project.MPC5674.FlexCAN_A.port=10001',

--- a/cm2350/tests/test_mpc5674_flexcan.py
+++ b/cm2350/tests/test_mpc5674_flexcan.py
@@ -208,739 +208,739 @@ def read_mb_data(emu, dev, mb):
 
 class MPC5674_FlexCAN_Test(MPC5674_Test):
     def set_sysclk_240mhz(self):
-        # Default PLL clock based on the PCB params selected for these tests is
-        # 60 MHz
-        self.assertEqual(self.emu.vw.config.project.MPC5674.FMPLL.extal, 40000000)
-        self.assertEqual(self.emu.fmpll.f_pll(), 60000000.0)
+        # default pll clock based on the pcb params selected for these tests is
+        # 60 mhz
+        self.assertequal(self.emu.vw.config.project.mpc5674.fmpll.extal, 40000000)
+        self.assertequal(self.emu.fmpll.f_pll(), 60000000.0)
 
-        # The max clock for the real hardware is 764 MHz:
-        #  (40 MHz * (50+16)) / ((4+1) * (1+1))
+        # the max clock for the real hardware is 764 mhz:
+        #  (40 mhz * (50+16)) / ((4+1) * (1+1))
         #
-        # But the more efficient clock speed used in actual hardware is 240 MHz
-        # which allows a bus speed of 120 MHz.
-        #  (40 MHz * (80+16)) / ((7+1) * (1+1))
+        # but the more efficient clock speed used in actual hardware is 240 mhz
+        # which allows a bus speed of 120 mhz.
+        #  (40 mhz * (80+16)) / ((7+1) * (1+1))
 
-        # ESYNCR1[EMFD] = 80
-        # ESYNCR1[EPREDIV] = 7
-        self.emu.writeMemValue(0xC3F80008, 0xF0070050, 4)
-        # ESYNCR2[ERFD] = 1
-        self.emu.writeMemValue(0xC3F8000C, 0x00000001, 4)
-        self.assertEqual(self.emu.fmpll.f_pll(), 240000000.0)
+        # esyncr1[emfd] = 80
+        # esyncr1[eprediv] = 7
+        self.emu.writememvalue(0xc3f80008, 0xf0070050, 4)
+        # esyncr2[erfd] = 1
+        self.emu.writememvalue(0xc3f8000c, 0x00000001, 4)
+        self.assertequal(self.emu.fmpll.f_pll(), 240000000.0)
 
-        # Now set the SIU peripheral configuration to allow the CPU frequency to
+        # now set the siu peripheral configuration to allow the cpu frequency to
         # be double the peripheral speed (otherwise the maximum bus/peripheral
-        # speed is 132 MHz
+        # speed is 132 mhz
 
-        # SYSDIV[IPCLKDIV] = 0
-        # SYSDIV[BYPASS] = 1
-        self.emu.writeMemValue(0xC3F909A0, 0x00000010, 4)
-        self.assertEqual(self.emu.siu.f_periph(), 120000000.0)
+        # sysdiv[ipclkdiv] = 0
+        # sysdiv[bypass] = 1
+        self.emu.writememvalue(0xc3f909a0, 0x00000010, 4)
+        self.assertequal(self.emu.siu.f_periph(), 120000000.0)
 
     def set_baudrates(self):
-        # Configure FMPLL to an appropriately reasonable example valid baud rate
+        # configure fmpll to an appropriately reasonable example valid baud rate
         self.set_sysclk_240mhz()
 
-        # Set each peripheral to different sclk rates so we can test that the
+        # set each peripheral to different sclk rates so we can test that the
         # emulated timer runs at an appropriately simulated rate.
-        ctrl_addrs = [a + FLEXCAN_CTRL_OFFSET for _, a in FLEXCAN_DEVICES]
+        ctrl_addrs = [a + flexcan_ctrl_offset for _, a in flexcan_devices]
 
-        # FlexCAN_A: 1 Mbps
+        # flexcan_a: 1 mbps
         #   - sclk = 120000000 / (14+1)
         #   - tq = sclk / (1 + (1+1) + (2+1) + (1+1))
-        val = (14 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
-                (2 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
-                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
-                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
-                (1 << FLEXCAN_CTRL_PROPSEG_SHIFT)
-        self.emu.writeMemValue(ctrl_addrs[0], val, 4)
-        self.assertEqual(self.emu.can[0].speed, 1000000)
+        val = (14 << flexcan_ctrl_presdiv_shift) | \
+                (2 << flexcan_ctrl_pseg1_shift) | \
+                (1 << flexcan_ctrl_pseg2_shift) | \
+                (flexcan_ctrl_clk_src_mask) | \
+                (1 << flexcan_ctrl_propseg_shift)
+        self.emu.writememvalue(ctrl_addrs[0], val, 4)
+        self.assertequal(self.emu.can[0].speed, 1000000)
 
-        # FlexCAN_B: 500 kbps
+        # flexcan_b: 500 kbps
         #   - sclk = 120000000 / (14+1)
         #   - tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-        val = (14 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
-                (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
-                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
-                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
-                (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
-        self.emu.writeMemValue(ctrl_addrs[1], val, 4)
-        self.assertEqual(self.emu.can[1].speed, 500000)
+        val = (14 << flexcan_ctrl_presdiv_shift) | \
+                (7 << flexcan_ctrl_pseg1_shift) | \
+                (1 << flexcan_ctrl_pseg2_shift) | \
+                (flexcan_ctrl_clk_src_mask) | \
+                (4 << flexcan_ctrl_propseg_shift)
+        self.emu.writememvalue(ctrl_addrs[1], val, 4)
+        self.assertequal(self.emu.can[1].speed, 500000)
 
-        #   FlexCAN_C: 250 kbps
+        #   flexcan_c: 250 kbps
         #   - sclk = 120000000 / (29+1)
         #   - tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-        val = (29 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
-                (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
-                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
-                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
-                (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
-        self.emu.writeMemValue(ctrl_addrs[2], val, 4)
-        self.assertEqual(self.emu.can[2].speed, 250000)
+        val = (29 << flexcan_ctrl_presdiv_shift) | \
+                (7 << flexcan_ctrl_pseg1_shift) | \
+                (1 << flexcan_ctrl_pseg2_shift) | \
+                (flexcan_ctrl_clk_src_mask) | \
+                (4 << flexcan_ctrl_propseg_shift)
+        self.emu.writememvalue(ctrl_addrs[2], val, 4)
+        self.assertequal(self.emu.can[2].speed, 250000)
 
-        # FlexCAN_D: 125 kbps
+        # flexcan_d: 125 kbps
         #   - sclk = 120000000 / (59+1)
         #   - tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-        val = (59 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
-                (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
-                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
-                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
-                (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
-        self.emu.writeMemValue(ctrl_addrs[3], val, 4)
-        self.assertEqual(self.emu.can[3].speed, 125000)
+        val = (59 << flexcan_ctrl_presdiv_shift) | \
+                (7 << flexcan_ctrl_pseg1_shift) | \
+                (1 << flexcan_ctrl_pseg2_shift) | \
+                (flexcan_ctrl_clk_src_mask) | \
+                (4 << flexcan_ctrl_propseg_shift)
+        self.emu.writememvalue(ctrl_addrs[3], val, 4)
+        self.assertequal(self.emu.can[3].speed, 125000)
 
     def test_flexcan_mcr_defaults(self):
         for idx in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[idx]
-            self.assertEqual(self.emu.can[idx].devname, devname)
+            devname, baseaddr = flexcan_devices[idx]
+            self.assertequal(self.emu.can[idx].devname, devname)
 
-            addr = baseaddr + FLEXCAN_MCR_OFFSET
+            addr = baseaddr + flexcan_mcr_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), FLEXCAN_MCR_DEFAULT_BYTES)
-            self.assertEqual(self.emu.readMemValue(addr, 4), FLEXCAN_MCR_DEFAULT)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.fen, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.soft_rst, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.supv, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.wrn_en, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.doze, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.srx_dis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mbfen, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.lprio_en, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.aen, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.idam, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.maxmb, 0x0F)
+            self.assertequal(self.emu.readmemory(addr, 4), flexcan_mcr_default_bytes)
+            self.assertequal(self.emu.readmemvalue(addr, 4), flexcan_mcr_default)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.fen, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.soft_rst, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.supv, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.wrn_en, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.doze, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.srx_dis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mbfen, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.lprio_en, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.aen, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.idam, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.maxmb, 0x0f)
 
     def test_flexcan_ctrl_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr = baseaddr + FLEXCAN_CTRL_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr = baseaddr + flexcan_ctrl_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.rjw, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.boff_msk, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.err_msk, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.twrn_msk, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.rwrn_msk, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.smp, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.boff_rec, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.tsyn, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lbuf, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.rjw, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.boff_msk, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.err_msk, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.twrn_msk, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.rwrn_msk, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.smp, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.boff_rec, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.tsyn, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lbuf, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
 
     def test_flexcan_timer_defaults(self):
-        test_addrs = [a + FLEXCAN_TIMER_OFFSET for _, a in FLEXCAN_DEVICES]
+        test_addrs = [a + flexcan_timer_offset for _, a in flexcan_devices]
         for addr in test_addrs:
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
 
-        # Start the timer for each peripheral, ensure that the timer value has
-        # changed and that none of the other CAN device timers moved
+        # start the timer for each peripheral, ensure that the timer value has
+        # changed and that none of the other can device timers moved
 
-        # CAN A
+        # can a
         self.emu.can[0]._timer.start()
         time.sleep(0.1)
-        self.assertNotEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertNotEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
+        self.assertnotequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertnotequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
 
-        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
 
         self.emu.can[0]._timer.stop()
-        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
 
-        # CAN B
+        # can b
         self.emu.can[1]._timer.start()
         time.sleep(0.1)
-        self.assertNotEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertNotEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
+        self.assertnotequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertnotequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
 
-        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
 
         self.emu.can[1]._timer.stop()
-        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
 
-        # CAN C
+        # can c
         self.emu.can[2]._timer.start()
         time.sleep(0.1)
-        self.assertNotEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertNotEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
+        self.assertnotequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertnotequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
 
-        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
 
         self.emu.can[2]._timer.stop()
-        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
 
-        # CAN D
+        # can d
         self.emu.can[3]._timer.start()
         time.sleep(0.1)
-        self.assertNotEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertNotEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
+        self.assertnotequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertnotequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
 
-        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
-        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
 
         self.emu.can[3]._timer.stop()
-        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
+        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
 
     def test_flexcan_rxgmask_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr = baseaddr + FLEXCAN_RXGMASK_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr = baseaddr + flexcan_rxgmask_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.rxgmask, 0xffffffff)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.rxgmask, 0xffffffff)
 
     def test_flexcan_rx14mask_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr = baseaddr + FLEXCAN_RX14MASK_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr = baseaddr + flexcan_rx14mask_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.rx14mask, 0xffffffff)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.rx14mask, 0xffffffff)
 
     def test_flexcan_rx15mask_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr = baseaddr + FLEXCAN_RX15MASK_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr = baseaddr + flexcan_rx15mask_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.rx15mask, 0xffffffff)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.rx15mask, 0xffffffff)
 
     def test_flexcan_ecr_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr = baseaddr + FLEXCAN_ECR_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr = baseaddr + flexcan_ecr_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.ecr.tx_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.ecr.rx_err, 0)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.ecr.tx_err, 0)
+            self.assertequal(self.emu.can[idx].registers.ecr.rx_err, 0)
 
     def test_flexcan_esr_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr = baseaddr + FLEXCAN_ESR_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr = baseaddr + flexcan_esr_offset
 
-            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.esr.twrn_int, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.rwrn_int, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.bit1_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.bit0_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.ack_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.crc_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.frm_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.stf_err, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.tx_wrn, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.rx_wrn, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.idle, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.txrx, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.flt_conf, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.boff_int, 0)
-            self.assertEqual(self.emu.can[idx].registers.esr.err_int, 0)
+            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.esr.twrn_int, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.rwrn_int, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.bit1_err, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.bit0_err, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.ack_err, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.crc_err, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.frm_err, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.stf_err, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.tx_wrn, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.rx_wrn, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.idle, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.txrx, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.flt_conf, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.boff_int, 0)
+            self.assertequal(self.emu.can[idx].registers.esr.err_int, 0)
 
     def test_flexcan_imask_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr1 = baseaddr + FLEXCAN_IMASK1_OFFSET
-            addr2 = baseaddr + FLEXCAN_IMASK2_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr1 = baseaddr + flexcan_imask1_offset
+            addr2 = baseaddr + flexcan_imask2_offset
 
-            # IMASK1
-            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.imask1, 0x00000000)
+            # imask1
+            self.assertequal(self.emu.readmemory(addr1, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.imask1, 0x00000000)
 
-            self.emu.writeMemory(addr1, b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemory(addr1, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr1, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.imask1, 0xffffffff)
+            self.emu.writememory(addr1, b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemory(addr1, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr1, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.imask1, 0xffffffff)
 
-            # IMASK2
-            self.assertEqual(self.emu.readMemory(addr2, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr2, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.imask2, 0x00000000)
+            # imask2
+            self.assertequal(self.emu.readmemory(addr2, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr2, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.imask2, 0x00000000)
 
-            self.emu.writeMemory(addr2, b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemory(addr2, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr2, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.imask2, 0xffffffff)
+            self.emu.writememory(addr2, b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemory(addr2, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr2, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.imask2, 0xffffffff)
 
     def test_flexcan_iflag_defaults(self):
         for idx in range(4):
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            addr1 = baseaddr + FLEXCAN_IFLAG1_OFFSET
-            addr2 = baseaddr + FLEXCAN_IFLAG2_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            addr1 = baseaddr + flexcan_iflag1_offset
+            addr2 = baseaddr + flexcan_iflag2_offset
 
-            # IFLAG1
-            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.iflag1, 0x00000000)
+            # iflag1
+            self.assertequal(self.emu.readmemory(addr1, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.iflag1, 0x00000000)
 
-            # Ensure the flag1 register are w1c and can't be set by writing
-            self.emu.writeMemory(addr1, b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.iflag1, 0x00000000)
+            # ensure the flag1 register are w1c and can't be set by writing
+            self.emu.writememory(addr1, b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemory(addr1, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.iflag1, 0x00000000)
 
-            self.emu.can[idx].registers.vsOverrideValue('iflag1', 0xffffffff)
+            self.emu.can[idx].registers.vsoverridevalue('iflag1', 0xffffffff)
 
-            self.assertEqual(self.emu.readMemory(addr1, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr1, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.iflag1, 0xffffffff)
+            self.assertequal(self.emu.readmemory(addr1, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr1, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.iflag1, 0xffffffff)
 
-            # Clear some flags
-            self.emu.writeMemory(addr1, b'\xa5\xa5\xa5\xa5')
-            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x5a\x5a\x5a\x5a')
-            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x5a5a5a5a)
-            self.assertEqual(self.emu.can[idx].registers.iflag1, 0x5a5a5a5a)
+            # clear some flags
+            self.emu.writememory(addr1, b'\xa5\xa5\xa5\xa5')
+            self.assertequal(self.emu.readmemory(addr1, 4), b'\x5a\x5a\x5a\x5a')
+            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x5a5a5a5a)
+            self.assertequal(self.emu.can[idx].registers.iflag1, 0x5a5a5a5a)
 
-            # IFLAG2
-            self.assertEqual(self.emu.readMemory(addr2, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr2, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.iflag2, 0x00000000)
+            # iflag2
+            self.assertequal(self.emu.readmemory(addr2, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr2, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.iflag2, 0x00000000)
 
-            # Ensure the flag2 register are w1c and can't be set by writing
-            self.emu.writeMemory(addr2, b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemory(addr2, 4), b'\x00\x00\x00\x00')
-            self.assertEqual(self.emu.readMemValue(addr2, 4), 0x00000000)
-            self.assertEqual(self.emu.can[idx].registers.iflag2, 0x00000000)
+            # ensure the flag2 register are w1c and can't be set by writing
+            self.emu.writememory(addr2, b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemory(addr2, 4), b'\x00\x00\x00\x00')
+            self.assertequal(self.emu.readmemvalue(addr2, 4), 0x00000000)
+            self.assertequal(self.emu.can[idx].registers.iflag2, 0x00000000)
 
-            self.emu.can[idx].registers.vsOverrideValue('iflag2', 0xffffffff)
+            self.emu.can[idx].registers.vsoverridevalue('iflag2', 0xffffffff)
 
-            self.assertEqual(self.emu.readMemory(addr2, 4), b'\xff\xff\xff\xff')
-            self.assertEqual(self.emu.readMemValue(addr2, 4), 0xffffffff)
-            self.assertEqual(self.emu.can[idx].registers.iflag2, 0xffffffff)
+            self.assertequal(self.emu.readmemory(addr2, 4), b'\xff\xff\xff\xff')
+            self.assertequal(self.emu.readmemvalue(addr2, 4), 0xffffffff)
+            self.assertequal(self.emu.can[idx].registers.iflag2, 0xffffffff)
 
-            # Clear some flags
-            self.emu.writeMemory(addr2, b'\x5a\x5a\x5a\x5a')
-            self.assertEqual(self.emu.readMemory(addr2, 4), b'\xa5\xa5\xa5\xa5')
-            self.assertEqual(self.emu.readMemValue(addr2, 4), 0xa5a5a5a5)
-            self.assertEqual(self.emu.can[idx].registers.iflag2, 0xa5a5a5a5)
+            # clear some flags
+            self.emu.writememory(addr2, b'\x5a\x5a\x5a\x5a')
+            self.assertequal(self.emu.readmemory(addr2, 4), b'\xa5\xa5\xa5\xa5')
+            self.assertequal(self.emu.readmemvalue(addr2, 4), 0xa5a5a5a5)
+            self.assertequal(self.emu.can[idx].registers.iflag2, 0xa5a5a5a5)
 
     def test_flexcan_modes(self):
         for idx in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[idx]
-            self.assertEqual(self.emu.can[idx].devname, devname)
+            devname, baseaddr = flexcan_devices[idx]
+            self.assertequal(self.emu.can[idx].devname, devname)
 
-            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
-            ctrl_addr = baseaddr + FLEXCAN_CTRL_OFFSET
+            mcr_addr = baseaddr + flexcan_mcr_offset
+            ctrl_addr = baseaddr + flexcan_ctrl_offset
 
-            # Should start off in DISABLE, but the MCR[MDIS] bit isn't set
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.DISABLE)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            # should start off in disable, but the mcr[mdis] bit isn't set
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.disable)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Writing the same value back to MCR should put the peripheral into
-            # FREEZE, MCR[MDISACK] should now be cleared
-            mcr_val = self.emu.readMemValue(mcr_addr, 4)
-            self.emu.writeMemValue(mcr_addr, mcr_val, 4)
+            # writing the same value back to mcr should put the peripheral into
+            # freeze, mcr[mdisack] should now be cleared
+            mcr_val = self.emu.readmemvalue(mcr_addr, 4)
+            self.emu.writememvalue(mcr_addr, mcr_val, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Writing only the FRZ and HALT bits should result in no change
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
+            # writing only the frz and halt bits should result in no change
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Clearing the MCR[HALT] bit should move the device to NORMAL mode
-            # and clear MCR[NOT_RDY] and MCR[FRZ_ACK]
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK, 4)
+            # clearing the mcr[halt] bit should move the device to normal mode
+            # and clear mcr[not_rdy] and mcr[frz_ack]
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Set MCR[MDIS] to move back to disabled, this should also set
-            # MCR[NOT_RDY] and MCR[MDISACK]
+            # set mcr[mdis] to move back to disabled, this should also set
+            # mcr[not_rdy] and mcr[mdisack]
             #
-            # MCR[FRZ] is also cleared by this change because the FRZ mask is
+            # mcr[frz] is also cleared by this change because the frz mask is
             # not written in this step.
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_MDIS_MASK, 4)
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_mdis_mask, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.DISABLE)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.disable)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Clearing MCR[MDIS] moves back to NORMAL
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            # clearing mcr[mdis] moves back to normal
+            self.emu.writememvalue(mcr_addr, 0, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Setting only MCR[HALT] should not change anything since the
-            # MCR[FRZ] bit is not set.
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_HALT_MASK, 4)
+            # setting only mcr[halt] should not change anything since the
+            # mcr[frz] bit is not set.
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_halt_mask, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Setting both HALT and FRZ moves the device back to FREEZE
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
+            # setting both halt and frz moves the device back to freeze
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Test out loopback and listen-only modes but first move to FREEZE.
+            # test out loopback and listen-only modes but first move to freeze.
             # this step isn't currently necessary but it is the more "correct"
             # way to change modes.
 
-            # Setting CTRL[LPB] should enable loopback mode once the device is
-            # back to NORMAL mode.
-            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_LPB_MASK, 4)
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            # setting ctrl[lpb] should enable loopback mode once the device is
+            # back to normal mode.
+            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_lpb_mask, 4)
+            self.emu.writememvalue(mcr_addr, 0, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.LOOP_BACK)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.loop_back)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # Back to FREEZE
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
+            # back to freeze
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
 
-            # Setting LOM and LPB should listen-only mode once the device is
-            # back to NORMAL mode.
-            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_LPB_MASK | FLEXCAN_CTRL_LOM_MASK, 4)
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            # setting lom and lpb should listen-only mode once the device is
+            # back to normal mode.
+            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_lpb_mask | flexcan_ctrl_lom_mask, 4)
+            self.emu.writememvalue(mcr_addr, 0, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.LISTEN_ONLY)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 1)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.listen_only)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 1)
 
-            # Back to FREEZE
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
+            # back to freeze
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
 
-            # Setting LOM will also set the device to listen-only mode
-            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_LOM_MASK, 4)
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            # setting lom will also set the device to listen-only mode
+            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_lom_mask, 4)
+            self.emu.writememvalue(mcr_addr, 0, 4)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.LISTEN_ONLY)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 1)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.listen_only)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 1)
 
     def test_flexcan_speed(self):
         for idx in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[idx]
-            self.assertEqual(self.emu.can[idx].devname, devname)
-            ctrl_addr = baseaddr + FLEXCAN_CTRL_OFFSET
+            devname, baseaddr = flexcan_devices[idx]
+            self.assertequal(self.emu.can[idx].devname, devname)
+            ctrl_addr = baseaddr + flexcan_ctrl_offset
 
-            # With the default clock source of EXTAL, and PRESDIV the SCLK is
-            # 40 MHz, and then the default bitrate is 10 Mbit/sec
-            self.assertEqual(self.emu.can[idx].speed, 10000000)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
+            # with the default clock source of extal, and presdiv the sclk is
+            # 40 mhz, and then the default bitrate is 10 mbit/sec
+            self.assertequal(self.emu.can[idx].speed, 10000000)
+            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
 
-            # With clock source of the bus/internal PLL, and PRESDIV the SCLK is
-            # 30 MHz, and then the default bitrate is 7.5 Mbit/sec
-            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_CLK_SRC_MASK, 4)
-            self.assertEqual(self.emu.can[idx].speed, 7500000)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
+            # with clock source of the bus/internal pll, and presdiv the sclk is
+            # 30 mhz, and then the default bitrate is 7.5 mbit/sec
+            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_clk_src_mask, 4)
+            self.assertequal(self.emu.can[idx].speed, 7500000)
+            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
 
-        # Configure FMPLL to an appropriately reasonable example valid baud rate
+        # configure fmpll to an appropriately reasonable example valid baud rate
         self.set_sysclk_240mhz()
 
         for idx in range(4):
-            # Force the CAN device to update the clock speed
-            self.emu.can[idx].updateSpeed()
+            # force the can device to update the clock speed
+            self.emu.can[idx].updatespeed()
 
-            _, baseaddr = FLEXCAN_DEVICES[idx]
-            ctrl_addr = baseaddr + FLEXCAN_CTRL_OFFSET
+            _, baseaddr = flexcan_devices[idx]
+            ctrl_addr = baseaddr + flexcan_ctrl_offset
 
-            # With clock source of the bus/internal PLL, and PRESDIV the SCLK is
-            # 120 MHz, and then the default bitrate is 30 Mbit/sec
-            self.assertEqual(self.emu.can[idx].speed, 30000000)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
+            # with clock source of the bus/internal pll, and presdiv the sclk is
+            # 120 mhz, and then the default bitrate is 30 mbit/sec
+            self.assertequal(self.emu.can[idx].speed, 30000000)
+            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
 
-            # A baudrate of 250000 can be achieved in a few ways, but one way
+            # a baudrate of 250000 can be achieved in a few ways, but one way
             # is:
             #   sclk = 120000000 / (29+1)
             #   tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-            val = (29 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
-                    (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
-                    (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
-                    (FLEXCAN_CTRL_CLK_SRC_MASK) | \
-                    (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
-            self.emu.writeMemValue(ctrl_addr, val, 4)
+            val = (29 << flexcan_ctrl_presdiv_shift) | \
+                    (7 << flexcan_ctrl_pseg1_shift) | \
+                    (1 << flexcan_ctrl_pseg2_shift) | \
+                    (flexcan_ctrl_clk_src_mask) | \
+                    (4 << flexcan_ctrl_propseg_shift)
+            self.emu.writememvalue(ctrl_addr, val, 4)
 
-            # - CTRL[CLK_SRC] set, the bus/internal PLL
-            # - CTRL[PRESDIV] is 29
-            # - CTRL[PSEG1] is 7
-            # - CTRL[PSEG2] is 1
-            # - CTRL[PROPSEG] is 4
-            # SCLK is 4 MHz, and the bitrate (tq) is 250000 Kbit/sec
-            self.assertEqual(self.emu.can[idx].speed, 250000)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 29)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 7)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 1)
-            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 4)
+            # - ctrl[clk_src] set, the bus/internal pll
+            # - ctrl[presdiv] is 29
+            # - ctrl[pseg1] is 7
+            # - ctrl[pseg2] is 1
+            # - ctrl[propseg] is 4
+            # sclk is 4 mhz, and the bitrate (tq) is 250000 kbit/sec
+            self.assertequal(self.emu.can[idx].speed, 250000)
+            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 29)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 7)
+            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 1)
+            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 4)
 
     def test_flexcan_timer(self):
-        # Because this test attempts to test the accuracy of emulated timers
+        # because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # Set standard bus speeds
+        # set standard bus speeds
         self.set_baudrates()
 
-        # at 1Mbps run for 0.05 msec CAN A should have a value of approximately
-        # 50000. Since the scaling time for this test is set to 0.1 set each
-        # bus to NORMAL and then wait 0.5 seconds before collecting the end
+        # at 1mbps run for 0.05 msec can a should have a value of approximately
+        # 50000. since the scaling time for this test is set to 0.1 set each
+        # bus to normal and then wait 0.5 seconds before collecting the end
         # timer values.
         for idx in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[idx]
-            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
-            timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
+            devname, baseaddr = flexcan_devices[idx]
+            mcr_addr = baseaddr + flexcan_mcr_offset
+            timer_addr = baseaddr + flexcan_timer_offset
 
-            # Expected ticks:
+            # expected ticks:
             expected_val = self.emu.can[idx].speed * 0.5 * self.emu._systime_scaling
 
-            # Margin of error is approximately 0.001 (so speed * 0.001 * 0.1)
-            # Because this is Dependant on the execution speed of the machine in
+            # margin of error is approximately 0.001 (so speed * 0.001 * 0.1)
+            # because this is dependant on the execution speed of the machine in
             # question increase to 0.005
             margin = self.emu.can[idx].speed * 0.005 * self.emu._systime_scaling
 
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            self.emu.writememvalue(mcr_addr, 0, 4)
 
             time.sleep(0.5)
-            val = self.emu.readMemValue(timer_addr, 4)
+            val = self.emu.readmemvalue(timer_addr, 4)
 
-            self.assertAlmostEqual(val, expected_val, delta=margin, msg=devname)
+            self.assertalmostequal(val, expected_val, delta=margin, msg=devname)
 
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL, devname)
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_MDIS_MASK, 4)
-            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.DISABLE, devname)
-            self.assertEqual(self.emu.readMemValue(timer_addr, 4), 0, devname)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal, devname)
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_mdis_mask, 4)
+            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.disable, devname)
+            self.assertequal(self.emu.readmemvalue(timer_addr, 4), 0, devname)
 
     def test_flexcan_tx(self):
-        # Because this test attempts to test the accuracy of emulated timers
+        # because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # Set standard bus speeds
+        # set standard bus speeds
         self.set_baudrates()
 
-        # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+        # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
         enabled_intrs = list(range(0, 8)) + list(range(24, 32)) + list(range(32, 48))
 
-        # Send a message from each bus and ensure the timestamp is correctly
+        # send a message from each bus and ensure the timestamp is correctly
         # updated, wait 0.10 seconds before sending and then check that the time
         # stamp is correct.
         for dev in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[dev]
-            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
-            timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
+            devname, baseaddr = flexcan_devices[dev]
+            mcr_addr = baseaddr + flexcan_mcr_offset
+            timer_addr = baseaddr + flexcan_timer_offset
 
-            # Generate one message for each mailbox
-            msgs = [generate_msg() for i in range(FLEXCAN_NUM_MBs)]
+            # generate one message for each mailbox
+            msgs = [generate_msg() for i in range(flexcan_num_mbs)]
 
-            # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
-            imask1_val = 0xFF0000FF
-            imask2_val = 0x0000FFFF
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK1_OFFSET, imask1_val, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK2_OFFSET, imask2_val, 4)
+            # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+            imask1_val = 0xff0000ff
+            imask2_val = 0x0000ffff
+            self.emu.writememvalue(baseaddr + flexcan_imask1_offset, imask1_val, 4)
+            self.emu.writememvalue(baseaddr + flexcan_imask2_offset, imask2_val, 4)
 
-            # Change mode to NORMAL, the timer now starts moving, but disable
+            # change mode to normal, the timer now starts moving, but disable
             # self-reception of messages to make this test simpler
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_SRX_DIS_MASK, 4)
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_srx_dis_mask, 4)
             start_time = time.time()
 
-            # Place messages into each mailbox and mark the mailbox as inactive
-            for mb in range(FLEXCAN_NUM_MBs):
-                # Generate a random priority (0 to 7) to ensure that the
+            # place messages into each mailbox and mark the mailbox as inactive
+            for mb in range(flexcan_num_mbs):
+                # generate a random priority (0 to 7) to ensure that the
                 # priority field is correctly removed during transmission
                 prio = random.randrange(0, 8)
-                data = msgs[mb].encode(code=flexcan.FLEXCAN_CODE_TX_INACTIVE, prio=prio)
+                data = msgs[mb].encode(code=flexcan.flexcan_code_tx_inactive, prio=prio)
                 write_mb_data(self.emu, dev, mb, data)
 
-                # Ensure that the written data matches what should have been
+                # ensure that the written data matches what should have been
                 # written
                 testmsg = '%s[%d]' % (devname, mb)
-                start = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
-                self.assertEqual(self.emu.readMemory(start, FLEXCAN_MBx_SIZE), data, msg=testmsg)
+                start = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                self.assertequal(self.emu.readmemory(start, flexcan_mbx_size), data, msg=testmsg)
 
-            # Ensure that no messages have been transmitted and there are no
+            # ensure that no messages have been transmitted and there are no
             # pending interrupts
-            self.assertEqual(self.emu.can[dev].getTransmittedObjs(), [], devname)
-            self.assertEqual(self._getPendingExceptions(), [], msg=devname)
+            self.assertequal(self.emu.can[dev].gettransmittedobjs(), [], devname)
+            self.assertequal(self._getpendingexceptions(), [], msg=devname)
 
-            # Wait some short time to let the timer run for a bit
+            # wait some short time to let the timer run for a bit
             time.sleep(0.5)
 
-            # For each CAN device only transmit from some of them:
-            #   CAN A: tx in all mailboxes
-            #   CAN B: tx in every other mailbox
-            #   CAN C: tx in every third mailbox
-            #   CAN D: tx in every fourth mailbox
-            tx_mbs = list(range(0, FLEXCAN_NUM_MBs, dev+1))
+            # for each can device only transmit from some of them:
+            #   can a: tx in all mailboxes
+            #   can b: tx in every other mailbox
+            #   can c: tx in every third mailbox
+            #   can d: tx in every fourth mailbox
+            tx_mbs = list(range(0, flexcan_num_mbs, dev+1))
 
             # temporarily disable the garbage collector
             gc.disable()
 
-            # Randomize the tx mailbox order now
+            # randomize the tx mailbox order now
             random.shuffle(tx_mbs)
             tx_times = {}
             for mb in tx_mbs:
-                # Save the timestamp that the message was sent
-                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
-                self.emu.writeMemValue(addr, flexcan.FLEXCAN_CODE_TX_ACTIVE, 1)
+                # save the timestamp that the message was sent
+                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                self.emu.writememvalue(addr, flexcan.flexcan_code_tx_active, 1)
                 tx_times[mb] = time.time()
 
             # it can be re-enabled now
             gc.enable()
 
-            # Now read all queued transmit messages
-            txd_msgs = self.emu.can[dev].getTransmittedObjs()
-            self.assertEqual(len(txd_msgs), len(tx_mbs), msg=devname)
+            # now read all queued transmit messages
+            txd_msgs = self.emu.can[dev].gettransmittedobjs()
+            self.assertequal(len(txd_msgs), len(tx_mbs), msg=devname)
 
-            # Ensure the correct IFLAGs are set
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            iflag2_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG2_OFFSET, 4)
+            # ensure the correct iflags are set
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            iflag2_val = self.emu.readmemvalue(baseaddr + flexcan_iflag2_offset, 4)
 
             if dev == 0:
-                # For CAN A every mailbox should have sent a message
-                self.assertEqual(iflag1_val, 0xFFFFFFFF, msg=devname)
-                self.assertEqual(iflag2_val, 0xFFFFFFFF, msg=devname)
+                # for can a every mailbox should have sent a message
+                self.assertequal(iflag1_val, 0xffffffff, msg=devname)
+                self.assertequal(iflag2_val, 0xffffffff, msg=devname)
             elif dev == 1:
-                # For CAN B every other mailbox should have sent a message
-                self.assertEqual(iflag1_val, 0x55555555, msg=devname)
-                self.assertEqual(iflag2_val, 0x55555555, msg=devname)
+                # for can b every other mailbox should have sent a message
+                self.assertequal(iflag1_val, 0x55555555, msg=devname)
+                self.assertequal(iflag2_val, 0x55555555, msg=devname)
             elif dev == 2:
-                # For CAN C every third mailbox should have sent a message
-                self.assertEqual(iflag1_val, 0x49249249, msg=devname)
-                self.assertEqual(iflag2_val, 0x92492492, msg=devname)
+                # for can c every third mailbox should have sent a message
+                self.assertequal(iflag1_val, 0x49249249, msg=devname)
+                self.assertequal(iflag2_val, 0x92492492, msg=devname)
             elif dev == 3:
-                # For CAN D every fourth mailbox should have sent a message
-                self.assertEqual(iflag1_val, 0x11111111, msg=devname)
-                self.assertEqual(iflag2_val, 0x11111111, msg=devname)
+                # for can d every fourth mailbox should have sent a message
+                self.assertequal(iflag1_val, 0x11111111, msg=devname)
+                self.assertequal(iflag2_val, 0x11111111, msg=devname)
 
             # calculate how many interrupts there should be and correlate the
-            # interrupts to the transmit AND interrupt enabled mailboxes
+            # interrupts to the transmit and interrupt enabled mailboxes
             tx_int_mbs = []
-            for mb in range(FLEXCAN_NUM_MBs):
+            for mb in range(flexcan_num_mbs):
                 testmsg = '%s[%d]' % (devname, mb)
                 if mb < 32:
                     mb_mask = 1 << mb
@@ -952,154 +952,154 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
                     mask = imask2_val
 
                 if flag & mb_mask:
-                    self.assertIn(mb, tx_mbs, msg=testmsg)
+                    self.assertin(mb, tx_mbs, msg=testmsg)
                     if mask & mb_mask:
                         tx_int_mbs.append(mb)
                 else:
-                    self.assertNotIn(mb, tx_mbs, msg=testmsg)
+                    self.assertnotin(mb, tx_mbs, msg=testmsg)
 
-            # It is expected that the calculated timestamp will be slightly
+            # it is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
             margin = self.emu.can[dev].speed * 0.0100 * self.emu._systime_scaling
 
-            # Confirm that the order of the generated interrupts matches both
+            # confirm that the order of the generated interrupts matches both
             # the order of the transmitted messages and the interrupt source for
-            # the Tx mailbox
-            excs = self._getPendingExceptions()
-            self.assertEqual(len(excs), len(tx_int_mbs), msg=devname)
+            # the tx mailbox
+            excs = self._getpendingexceptions()
+            self.assertequal(len(excs), len(tx_int_mbs), msg=devname)
             exc_iter = iter(excs)
             txd_msgs_iter = iter(txd_msgs)
 
-            # Iterate through the mailboxes based on the order messages were
+            # iterate through the mailboxes based on the order messages were
             # transmitted
             for mb in tx_mbs:
                 testmsg = '%s[%d]' % (devname, mb)
 
-                # Confirm that the message contents are correct
+                # confirm that the message contents are correct
                 txd_msg = next(txd_msgs_iter)
-                self.assertEqual(txd_msg, msgs[mb], msg=testmsg)
+                self.assertequal(txd_msg, msgs[mb], msg=testmsg)
 
-                # Confirm that the timestamp is accurate
+                # confirm that the timestamp is accurate
                 tx_delay = tx_times[mb] - start_time
-                expected_ticks = int(self.emu.can[dev].speed * tx_delay * self.emu._systime_scaling) & 0xFFFF
+                expected_ticks = int(self.emu.can[dev].speed * tx_delay * self.emu._systime_scaling) & 0xffff
 
-                ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
-                timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
+                ts_offset = (mb * flexcan_mbx_size) + 2
+                timestamp = struct.unpack_from('>h', self.emu.can[dev].registers.mb.value, ts_offset)[0]
 
-                self.assertAlmostEqual(timestamp, expected_ticks, delta=margin, msg=testmsg)
+                self.assertalmostequal(timestamp, expected_ticks, delta=margin, msg=testmsg)
 
-                # Lastly, a mailbox should only have a corresponding interrupt
+                # lastly, a mailbox should only have a corresponding interrupt
                 # if the interrupt mask is set
                 if mb in tx_int_mbs:
-                    self.assertEqual(next(exc_iter), get_int(dev, mb), msg=testmsg)
+                    self.assertequal(next(exc_iter), get_int(dev, mb), msg=testmsg)
 
-            # Now ensure that all mailboxes that were not in the list are still
+            # now ensure that all mailboxes that were not in the list are still
             # inactive
-            for mb in range(FLEXCAN_NUM_MBs):
+            for mb in range(flexcan_num_mbs):
                 if mb not in tx_mbs:
                     testmsg = '%s[%d]' % (devname, mb)
 
-                    # Ensure that inactive mailboxes have the same data and
-                    # still have a CODE of TX_INACTIVE, and the TIMESTAMP is
+                    # ensure that inactive mailboxes have the same data and
+                    # still have a code of tx_inactive, and the timestamp is
                     # still 0
-                    code_offset = mb * FLEXCAN_MBx_SIZE
+                    code_offset = mb * flexcan_mbx_size
                     code = self.emu.can[dev].registers.mb[code_offset]
-                    self.assertEqual(code, flexcan.FLEXCAN_CODE_TX_INACTIVE, msg=testmsg)
-                    code_addr = baseaddr + FLEXCAN_MB_OFFSET + code_offset
-                    self.assertEqual(self.emu.readMemValue(code_addr, 1),
-                            flexcan.FLEXCAN_CODE_TX_INACTIVE, msg=testmsg)
+                    self.assertequal(code, flexcan.flexcan_code_tx_inactive, msg=testmsg)
+                    code_addr = baseaddr + flexcan_mb_offset + code_offset
+                    self.assertequal(self.emu.readmemvalue(code_addr, 1),
+                            flexcan.flexcan_code_tx_inactive, msg=testmsg)
 
-                    ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
-                    timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
-                    self.assertEqual(timestamp, 0, msg=testmsg)
-                    ts_addr = baseaddr + FLEXCAN_MB_OFFSET + ts_offset
-                    self.assertEqual(self.emu.readMemValue(ts_addr, 2), 0, msg=testmsg)
+                    ts_offset = (mb * flexcan_mbx_size) + 2
+                    timestamp = struct.unpack_from('>h', self.emu.can[dev].registers.mb.value, ts_offset)[0]
+                    self.assertequal(timestamp, 0, msg=testmsg)
+                    ts_addr = baseaddr + flexcan_mb_offset + ts_offset
+                    self.assertequal(self.emu.readmemvalue(ts_addr, 2), 0, msg=testmsg)
 
     def test_flexcan_rx(self):
-        # Because this test attempts to test the accuracy of emulated timers
+        # because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # Set standard bus speeds
+        # set standard bus speeds
         self.set_baudrates()
 
-        # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+        # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
         enabled_intrs = list(range(0, 8)) + list(range(24, 32)) + list(range(32, 48))
 
-        # Send a message from each bus and ensure the timestamp is correctly
+        # send a message from each bus and ensure the timestamp is correctly
         # updated, wait 0.10 seconds before sending and then check that the time
         # stamp is correct.
 
         for dev in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[dev]
-            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
-            timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
+            devname, baseaddr = flexcan_devices[dev]
+            mcr_addr = baseaddr + flexcan_mcr_offset
+            timer_addr = baseaddr + flexcan_timer_offset
 
-            # For each CAN device only enable some mailboxes to receive:
-            #   CAN A: rx in all mailboxes
-            #   CAN B: rx in every other mailbox
-            #   CAN C: rx in every third mailbox
-            #   CAN D: rx in every fourth mailbox
-            # Set those mailboxes to RX_EMPTY now
-            rx_mbs = list(range(0, FLEXCAN_NUM_MBs, dev+1))
+            # for each can device only enable some mailboxes to receive:
+            #   can a: rx in all mailboxes
+            #   can b: rx in every other mailbox
+            #   can c: rx in every third mailbox
+            #   can d: rx in every fourth mailbox
+            # set those mailboxes to rx_empty now
+            rx_mbs = list(range(0, flexcan_num_mbs, dev+1))
             for mb in rx_mbs:
-                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
-                self.emu.writeMemValue(addr, flexcan.FLEXCAN_CODE_RX_EMPTY, 1)
+                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                self.emu.writememvalue(addr, flexcan.flexcan_code_rx_empty, 1)
 
-            # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK1_OFFSET, 0xFF0000FF, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK2_OFFSET, 0x0000FFFF, 4)
+            # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+            self.emu.writememvalue(baseaddr + flexcan_imask1_offset, 0xff0000ff, 4)
+            self.emu.writememvalue(baseaddr + flexcan_imask2_offset, 0x0000ffff, 4)
 
-            # Generate one message for each mailbox that can receive, because a
-            # message with ID 0 would match a mailbox with the entire mask set
-            # and the filter value of 0, make the minimum ID 1
+            # generate one message for each mailbox that can receive, because a
+            # message with id 0 would match a mailbox with the entire mask set
+            # and the filter value of 0, make the minimum id 1
             msgs = [generate_msg(rtr=0, min_id=1) for i in range(len(rx_mbs))]
 
-            # Change mode to NORMAL
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            # change mode to normal
+            self.emu.writememvalue(mcr_addr, 0, 4)
 
-            # Call the processReceivedData function to mimic what the emulator
-            # calls when a message is received during normal execution.  Because
-            # the default filters are all 1's and no ID masks were defined in
+            # call the processreceiveddata function to mimic what the emulator
+            # calls when a message is received during normal execution.  because
+            # the default filters are all 1's and no id masks were defined in
             # any of the valid receive mailboxes, these messages should all just
             # be discarded.
             for mb, msg in zip(rx_mbs, msgs):
-                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
-                self.emu.can[dev].processReceivedData(msg)
+                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                self.emu.can[dev].processreceiveddata(msg)
 
-            # Loop through the mailboxes and ensure they are all still empty.
-            inactive_mb = b'\x00' * FLEXCAN_MBx_SIZE
-            empty_mb = b'\x04' + b'\x00' * (FLEXCAN_MBx_SIZE - 1)
-            for mb in range(FLEXCAN_NUM_MBs):
+            # loop through the mailboxes and ensure they are all still empty.
+            inactive_mb = b'\x00' * flexcan_mbx_size
+            empty_mb = b'\x04' + b'\x00' * (flexcan_mbx_size - 1)
+            for mb in range(flexcan_num_mbs):
                 testmsg = '%s[%d]' % (devname, mb)
-                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
-                # Ensure that nothing has been received in this mailbox, but the
-                # CODE is still correct
+                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                # ensure that nothing has been received in this mailbox, but the
+                # code is still correct
                 if mb in rx_mbs:
-                    self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), empty_mb, msg=testmsg)
+                    self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), empty_mb, msg=testmsg)
                 else:
-                    self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), inactive_mb, msg=testmsg)
+                    self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), inactive_mb, msg=testmsg)
 
-            # Ensure there are no pending interrupts
-            self.assertEqual(self._getPendingExceptions(), [], msg=devname)
+            # ensure there are no pending interrupts
+            self.assertequal(self._getpendingexceptions(), [], msg=devname)
 
-            # Now clear out the RXG, RX14, and RX15 masks, these must be changed
-            # in FREEZE mode
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_RXGMASK_OFFSET, 0, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_RX14MASK_OFFSET, 0, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_RX15MASK_OFFSET, 0, 4)
+            # now clear out the rxg, rx14, and rx15 masks, these must be changed
+            # in freeze mode
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
+            self.emu.writememvalue(baseaddr + flexcan_rxgmask_offset, 0, 4)
+            self.emu.writememvalue(baseaddr + flexcan_rx14mask_offset, 0, 4)
+            self.emu.writememvalue(baseaddr + flexcan_rx15mask_offset, 0, 4)
 
-            # Now move back to normal mode
-            self.emu.writeMemValue(mcr_addr, 0, 4)
+            # now move back to normal mode
+            self.emu.writememvalue(mcr_addr, 0, 4)
             start_time = time.time()
 
-            last_mb = None
-            last_timestamp = None
+            last_mb = none
+            last_timestamp = none
 
-            # It is expected that the calculated timestamp will be slightly
+            # it is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
             margin = self.emu.can[dev].speed * 0.0050 * self.emu._systime_scaling
@@ -1107,137 +1107,137 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # temporarily disable the garbage collector
             gc.disable()
 
-            # Call the processReceivedData function to mimic what the emulator
-            # calls when a message is received during normal execution.  Because
+            # call the processreceiveddata function to mimic what the emulator
+            # calls when a message is received during normal execution.  because
             # no filtering or masking is set up the messages should be placed
             # into the first empty mailbox
             for mb, msg in zip(rx_mbs, msgs):
                 testmsg = '%s[%d]' % (devname, mb)
-                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
 
-                self.emu.can[dev].processReceivedData(msg)
+                self.emu.can[dev].processreceiveddata(msg)
 
-                # Confirm that the timestamp is accurate. The timer has probably
+                # confirm that the timestamp is accurate. the timer has probably
                 # wrapped by now so ensure it is limited to 16 bits
                 rx_delay = time.time() - start_time
-                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xFFFF
+                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xffff
 
-                ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
-                timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
-                self.assertAlmostEqual(timestamp, expected_ticks, delta=margin, msg=testmsg)
+                ts_offset = (mb * flexcan_mbx_size) + 2
+                timestamp = struct.unpack_from('>h', self.emu.can[dev].registers.mb.value, ts_offset)[0]
+                self.assertalmostequal(timestamp, expected_ticks, delta=margin, msg=testmsg)
 
                 last_mb = mb
                 last_timestamp = timestamp
 
-                # Now that the timestamp has been confirmed to be within the
+                # now that the timestamp has been confirmed to be within the
                 # expected range, ensure that the message in the mailbox matches
                 # what is expected for the received message
-                rx_msg_data = msg.encode(code=flexcan.FLEXCAN_CODE_RX_FULL, timestamp=timestamp)
-                self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), rx_msg_data, msg=testmsg)
+                rx_msg_data = msg.encode(code=flexcan.flexcan_code_rx_full, timestamp=timestamp)
+                self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), rx_msg_data, msg=testmsg)
 
-                # Ensure that there is a pending interrupt for this mailbox
+                # ensure that there is a pending interrupt for this mailbox
                 if mb in enabled_intrs:
-                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, mb)], msg=testmsg)
+                    self.assertequal(self._getpendingexceptions(), [get_int(dev, mb)], msg=testmsg)
                 else:
-                    self.assertEqual(self._getPendingExceptions(), [], msg=testmsg)
+                    self.assertequal(self._getpendingexceptions(), [], msg=testmsg)
 
             # it can be re-enabled now
             gc.enable()
 
-            # There should be no more interrupts pending
-            self.assertEqual(self._getPendingExceptions(), [], msg=testmsg)
+            # there should be no more interrupts pending
+            self.assertequal(self._getpendingexceptions(), [], msg=testmsg)
 
-            # Ensure the correct IFLAGs are set
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            iflag2_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG2_OFFSET, 4)
+            # ensure the correct iflags are set
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            iflag2_val = self.emu.readmemvalue(baseaddr + flexcan_iflag2_offset, 4)
             if dev == 0:
-                # For CAN A every mailbox should have a message
-                self.assertEqual(iflag1_val, 0xFFFFFFFF, msg=devname)
-                self.assertEqual(iflag2_val, 0xFFFFFFFF, msg=devname)
+                # for can a every mailbox should have a message
+                self.assertequal(iflag1_val, 0xffffffff, msg=devname)
+                self.assertequal(iflag2_val, 0xffffffff, msg=devname)
             elif dev == 1:
-                # For CAN B every other mailbox should have a message
-                self.assertEqual(iflag1_val, 0x55555555, msg=devname)
-                self.assertEqual(iflag2_val, 0x55555555, msg=devname)
+                # for can b every other mailbox should have a message
+                self.assertequal(iflag1_val, 0x55555555, msg=devname)
+                self.assertequal(iflag2_val, 0x55555555, msg=devname)
             elif dev == 2:
-                # For CAN C every third mailbox should have a message
-                self.assertEqual(iflag1_val, 0x49249249, msg=devname)
-                self.assertEqual(iflag2_val, 0x92492492, msg=devname)
+                # for can c every third mailbox should have a message
+                self.assertequal(iflag1_val, 0x49249249, msg=devname)
+                self.assertequal(iflag2_val, 0x92492492, msg=devname)
             elif dev == 3:
-                # For CAN D every fourth mailbox should have a message
-                self.assertEqual(iflag1_val, 0x11111111, msg=devname)
-                self.assertEqual(iflag2_val, 0x11111111, msg=devname)
+                # for can d every fourth mailbox should have a message
+                self.assertequal(iflag1_val, 0x11111111, msg=devname)
+                self.assertequal(iflag2_val, 0x11111111, msg=devname)
 
-            # Now ensure that all mailboxes that were not in the list are still
+            # now ensure that all mailboxes that were not in the list are still
             # inactive and empty
-            for mb in range(FLEXCAN_NUM_MBs):
+            for mb in range(flexcan_num_mbs):
                 if mb not in rx_mbs:
-                    addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                    addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
 
-                    # Ensure that nothing has been received in this mailbox
-                    self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), inactive_mb, msg=testmsg)
+                    # ensure that nothing has been received in this mailbox
+                    self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), inactive_mb, msg=testmsg)
 
-            # Generate one more message and send it, this should cause the CODE
-            # of the last mailbox configured for receive to be set to OVERRUN
+            # generate one more message and send it, this should cause the code
+            # of the last mailbox configured for receive to be set to overrun
             # but should not generate any new interrupts
             overflow_msg = generate_msg(rtr=0)
 
-            # Ensure that this doesn't match the last sent message (which should
+            # ensure that this doesn't match the last sent message (which should
             # be in the last mailbox)
             #
-            self.assertNotEqual(overflow_msg, msgs[-1], devname)
-            self.emu.can[dev].processReceivedData(overflow_msg)
+            self.assertnotequal(overflow_msg, msgs[-1], devname)
+            self.emu.can[dev].processreceiveddata(overflow_msg)
 
-            # Ensure that the message in the last receive mailbox still matches
+            # ensure that the message in the last receive mailbox still matches
             # the last message received
             testmsg = '%s[%d]' % (devname, last_mb)
-            overflow_msg_data = msgs[-1].encode(code=flexcan.FLEXCAN_CODE_RX_OVERRUN, timestamp=last_timestamp)
-            addr = baseaddr + FLEXCAN_MB_OFFSET + (last_mb * FLEXCAN_MBx_SIZE)
-            self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), overflow_msg_data, msg=testmsg)
+            overflow_msg_data = msgs[-1].encode(code=flexcan.flexcan_code_rx_overrun, timestamp=last_timestamp)
+            addr = baseaddr + flexcan_mb_offset + (last_mb * flexcan_mbx_size)
+            self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), overflow_msg_data, msg=testmsg)
 
-            # And ensure that there are no new interrupts
-            self.assertEqual(self._getPendingExceptions(), [], msg=testmsg)
+            # and ensure that there are no new interrupts
+            self.assertequal(self._getpendingexceptions(), [], msg=testmsg)
 
     def test_flexcan_rx_fifo(self):
-        # Because this test attempts to test the accuracy of emulated timers
+        # because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # Set standard bus speeds
+        # set standard bus speeds
         self.set_baudrates()
 
-        # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+        # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
         enabled_intrs = list(range(0, 8)) + list(range(24, 32)) + list(range(32, 48))
 
         for dev in range(4):
-            devname, baseaddr = FLEXCAN_DEVICES[dev]
-            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
+            devname, baseaddr = flexcan_devices[dev]
+            mcr_addr = baseaddr + flexcan_mcr_offset
 
-            # Configure the following things:
-            # - Enable all interrupts
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK1_OFFSET, 0xFFFFFFFF, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK2_OFFSET, 0xFFFFFFFF, 4)
+            # configure the following things:
+            # - enable all interrupts
+            self.emu.writememvalue(baseaddr + flexcan_imask1_offset, 0xffffffff, 4)
+            self.emu.writememvalue(baseaddr + flexcan_imask2_offset, 0xffffffff, 4)
 
-            # - Clear all filter masks
-            self.emu.writeMemValue(baseaddr + FLEXCAN_RXGMASK_OFFSET, 0, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_RX14MASK_OFFSET, 0, 4)
-            self.emu.writeMemValue(baseaddr + FLEXCAN_RX15MASK_OFFSET, 0, 4)
+            # - clear all filter masks
+            self.emu.writememvalue(baseaddr + flexcan_rxgmask_offset, 0, 4)
+            self.emu.writememvalue(baseaddr + flexcan_rx14mask_offset, 0, 4)
+            self.emu.writememvalue(baseaddr + flexcan_rx15mask_offset, 0, 4)
 
-            # - Set all non-RxFIFO mailboxes to INACTIVE
-            for mb in range(6, FLEXCAN_NUM_MBs):
-                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
-                self.emu.writeMemValue(addr, flexcan.FLEXCAN_CODE_RX_INACTIVE, 1)
+            # - set all non-rxfifo mailboxes to inactive
+            for mb in range(6, flexcan_num_mbs):
+                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                self.emu.writememvalue(addr, flexcan.flexcan_code_rx_inactive, 1)
 
-            # - Change mode to NORMAL and enable Rx FIFO
-            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FEN_MASK, 4)
-            self.assertEqual(self.emu.can[dev].mode, flexcan.FLEXCAN_MODE.NORMAL, devname)
-            self.assertEqual(self.emu.can[dev].registers.mcr.fen, 1, devname)
+            # - change mode to normal and enable rx fifo
+            self.emu.writememvalue(mcr_addr, flexcan_mcr_fen_mask, 4)
+            self.assertequal(self.emu.can[dev].mode, flexcan.flexcan_mode.normal, devname)
+            self.assertequal(self.emu.can[dev].registers.mcr.fen, 1, devname)
             start_time = time.time()
 
-            # Generate 6 messages to send
+            # generate 6 messages to send
             msgs = [generate_msg() for i in range(6)]
 
-            # It is expected that the calculated timestamp will be slightly
+            # it is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
             margin = self.emu.can[dev].speed * 0.0050 * self.emu._systime_scaling
@@ -1245,120 +1245,120 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # temporarily disable the garbage collector
             gc.disable()
 
-            # The RxFIFO can hold 6 messages, each received message should
-            # generate a RxFIFO Msg Available interrupt (MB5), when the last
-            # message is queued an RxFIFO Warning interrupt (MB6) should be
+            # the rxfifo can hold 6 messages, each received message should
+            # generate a rxfifo msg available interrupt (mb5), when the last
+            # message is queued an rxfifo warning interrupt (mb6) should be
             # generated
             rx_times = []
             for i in range(len(msgs)):
-                testmsg = '%s RxFIFO[%d]' % (devname, i)
-                self.emu.can[dev].processReceivedData(msgs[i])
+                testmsg = '%s rxfifo[%d]' % (devname, i)
+                self.emu.can[dev].processreceiveddata(msgs[i])
                 rx_times.append(time.time())
                 time.sleep(0.1)
 
-                # There should be one RxFIFO Msg Available interrupt (MB5) when
-                # the first message is sent, then an RxFIFO Warning interrupt
-                # (MB6) after the 6th message is sent.
+                # there should be one rxfifo msg available interrupt (mb5) when
+                # the first message is sent, then an rxfifo warning interrupt
+                # (mb6) after the 6th message is sent.
                 if i == 0:
-                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, 5)], msg=testmsg)
+                    self.assertequal(self._getpendingexceptions(), [get_int(dev, 5)], msg=testmsg)
                 elif i == 5:
-                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, 6)], msg=testmsg)
+                    self.assertequal(self._getpendingexceptions(), [get_int(dev, 6)], msg=testmsg)
 
-            # Only MB5 and MB6 interrupt flags should be set
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            iflag2_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG2_OFFSET, 4)
-            self.assertEqual(iflag1_val, 0x00000060, msg=devname)
-            self.assertEqual(iflag2_val, 0x00000000, msg=devname)
+            # only mb5 and mb6 interrupt flags should be set
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            iflag2_val = self.emu.readmemvalue(baseaddr + flexcan_iflag2_offset, 4)
+            self.assertequal(iflag1_val, 0x00000060, msg=devname)
+            self.assertequal(iflag2_val, 0x00000000, msg=devname)
 
-            # Send one more message and ensure the RxFIFO Overflow interrupt
-            # (MB7) happens
+            # send one more message and ensure the rxfifo overflow interrupt
+            # (mb7) happens
             lost_msg = generate_msg()
-            self.emu.can[dev].processReceivedData(lost_msg)
+            self.emu.can[dev].processreceiveddata(lost_msg)
 
-            self.assertEqual(self._getPendingExceptions(), [get_int(dev, 7)], msg=testmsg)
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            self.assertEqual(iflag1_val, 0x000000E0, msg=devname)
+            self.assertequal(self._getpendingexceptions(), [get_int(dev, 7)], msg=testmsg)
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            self.assertequal(iflag1_val, 0x000000e0, msg=devname)
 
-            # Now read a message from the RxFIFO (MB0).
-            # Randomize how this data is read from the mailbox registers, it
+            # now read a message from the rxfifo (mb0).
+            # randomize how this data is read from the mailbox registers, it
             # can be read in 1, 2 or 4 byte chunks.
             first_msg = read_mb_data(self.emu, dev, 0)
             rx_msgs = [first_msg]
 
-            # Reading the FIFO without clearing the interrupt flag should not
+            # reading the fifo without clearing the interrupt flag should not
             # change the available data, read again and confirm the data matches
-            self.assertEqual(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
+            self.assertequal(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
 
-            # Clear the overflow and warning interrupt flags and ensure that the
-            # message in MB0 doesn't change
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 0x000000C0, 4)
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            self.assertEqual(iflag1_val, 0x00000020, msg=devname)
-            self.assertEqual(self._getPendingExceptions(), [], msg=devname)
+            # clear the overflow and warning interrupt flags and ensure that the
+            # message in mb0 doesn't change
+            self.emu.writememvalue(baseaddr + flexcan_iflag1_offset, 0x000000c0, 4)
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            self.assertequal(iflag1_val, 0x00000020, msg=devname)
+            self.assertequal(self._getpendingexceptions(), [], msg=devname)
 
-            self.assertEqual(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
+            self.assertequal(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
 
-            # Clear the MB5 interrupt flag and ensure that a new RxFIFO Msg
-            # Available interrupt (MB5) happens and that a new message is
-            # available in MB0
-            self.emu.writeMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 0x00000020, 4)
-            self.assertEqual(self._getPendingExceptions(), [get_int(dev, 5)], msg=devname)
+            # clear the mb5 interrupt flag and ensure that a new rxfifo msg
+            # available interrupt (mb5) happens and that a new message is
+            # available in mb0
+            self.emu.writememvalue(baseaddr + flexcan_iflag1_offset, 0x00000020, 4)
+            self.assertequal(self._getpendingexceptions(), [get_int(dev, 5)], msg=devname)
 
-            self.assertNotEqual(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
+            self.assertnotequal(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
 
-            # the MB5 interrupt flag should be set again
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            self.assertEqual(iflag1_val, 0x00000020, msg=devname)
+            # the mb5 interrupt flag should be set again
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            self.assertequal(iflag1_val, 0x00000020, msg=devname)
 
-            # Send another message and ensure the RxFIFO Warning is set again
+            # send another message and ensure the rxfifo warning is set again
             msgs.append(generate_msg())
-            self.emu.can[dev].processReceivedData(msgs[-1])
+            self.emu.can[dev].processreceiveddata(msgs[-1])
             rx_times.append(time.time())
 
-            self.assertEqual(self._getPendingExceptions(), [get_int(dev, 6)], msg=testmsg)
-            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
-            self.assertEqual(iflag1_val, 0x00000060, msg=devname)
+            self.assertequal(self._getpendingexceptions(), [get_int(dev, 6)], msg=testmsg)
+            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+            self.assertequal(iflag1_val, 0x00000060, msg=devname)
 
-            # Read the remaining 5 messages from the RxFIFO
+            # read the remaining 5 messages from the rxfifo
             while iflag1_val:
-                # Save the message in MB0
+                # save the message in mb0
                 msg = read_mb_data(self.emu, dev, 0)
                 rx_msgs.append(msg)
 
-                # Clear the interrupt flags, this should trigger a new interrupt
-                # if we have not read all of the messages from the FIFO
-                self.emu.writeMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, iflag1_val, 4)
-                iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+                # clear the interrupt flags, this should trigger a new interrupt
+                # if we have not read all of the messages from the fifo
+                self.emu.writememvalue(baseaddr + flexcan_iflag1_offset, iflag1_val, 4)
+                iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
 
                 if len(rx_msgs) != len(msgs):
-                    self.assertEqual(iflag1_val, 0x00000020, msg=devname)
-                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, 5)], msg=devname)
+                    self.assertequal(iflag1_val, 0x00000020, msg=devname)
+                    self.assertequal(self._getpendingexceptions(), [get_int(dev, 5)], msg=devname)
                 else:
-                    self.assertEqual(iflag1_val, 0x00000000, msg=devname)
+                    self.assertequal(iflag1_val, 0x00000000, msg=devname)
 
-            # Sanity check, the number of received messages should now match the
+            # sanity check, the number of received messages should now match the
             # number of sent messages and the number of receive times recorded.
-            self.assertEqual(len(rx_msgs), len(msgs), msg=devname)
-            self.assertEqual(len(rx_msgs), len(rx_times), msg=devname)
+            self.assertequal(len(rx_msgs), len(msgs), msg=devname)
+            self.assertequal(len(rx_msgs), len(rx_times), msg=devname)
 
             # it can be re-enabled now
             gc.enable()
 
-            # Go through the received messages and timestamps and ensure that
+            # go through the received messages and timestamps and ensure that
             # messages were received correctly.
             for i in range(len(msgs)):
-                testmsg = '%s RxFIFO[%d]' % (devname, i)
+                testmsg = '%s rxfifo[%d]' % (devname, i)
                 rx_delay = rx_times[i] - start_time
-                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xFFFF
+                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xffff
 
-                timestamp = struct.unpack_from('>H', rx_msgs[i], 2)[0]
-                self.assertAlmostEqual(timestamp, expected_ticks, delta=margin, msg=testmsg)
+                timestamp = struct.unpack_from('>h', rx_msgs[i], 2)[0]
+                self.assertalmostequal(timestamp, expected_ticks, delta=margin, msg=testmsg)
 
-                # Now that the timestamp has been confirmed to be within the
+                # now that the timestamp has been confirmed to be within the
                 # expected range, ensure that the received message in the
                 # matches what was sent
                 msg_data = msgs[i].encode(code=0, timestamp=timestamp)
-                self.assertEqual(rx_msgs[i], msg_data, msg=testmsg)
+                self.assertequal(rx_msgs[i], msg_data, msg=testmsg)
 
     @unittest.skip('todo')
     def test_flexcan_rx_filters(self):
@@ -1378,8 +1378,7 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
 
 
 class MPC5674_FlexCAN_RealIO(MPC5674_Test):
-    args = [
-        '-c',
+    args = MPC5674_Test.args + [
         '-O', 'project.MPC5674.FlexCAN_A.port=10001',
         '-O', 'project.MPC5674.FlexCAN_B.port=10002',
         '-O', 'project.MPC5674.FlexCAN_C.port=10003',

--- a/cm2350/tests/test_mpc5674_flexcan.py
+++ b/cm2350/tests/test_mpc5674_flexcan.py
@@ -208,739 +208,739 @@ def read_mb_data(emu, dev, mb):
 
 class MPC5674_FlexCAN_Test(MPC5674_Test):
     def set_sysclk_240mhz(self):
-        # default pll clock based on the pcb params selected for these tests is
-        # 60 mhz
-        self.assertequal(self.emu.vw.config.project.mpc5674.fmpll.extal, 40000000)
-        self.assertequal(self.emu.fmpll.f_pll(), 60000000.0)
+        # Default PLL clock based on the PCB params selected for these tests is
+        # 60 MHz
+        self.assertEqual(self.emu.vw.config.project.MPC5674.FMPLL.extal, 40000000)
+        self.assertEqual(self.emu.fmpll.f_pll(), 60000000.0)
 
-        # the max clock for the real hardware is 764 mhz:
-        #  (40 mhz * (50+16)) / ((4+1) * (1+1))
+        # The max clock for the real hardware is 764 MHz:
+        #  (40 MHz * (50+16)) / ((4+1) * (1+1))
         #
-        # but the more efficient clock speed used in actual hardware is 240 mhz
-        # which allows a bus speed of 120 mhz.
-        #  (40 mhz * (80+16)) / ((7+1) * (1+1))
+        # But the more efficient clock speed used in actual hardware is 240 MHz
+        # which allows a bus speed of 120 MHz.
+        #  (40 MHz * (80+16)) / ((7+1) * (1+1))
 
-        # esyncr1[emfd] = 80
-        # esyncr1[eprediv] = 7
-        self.emu.writememvalue(0xc3f80008, 0xf0070050, 4)
-        # esyncr2[erfd] = 1
-        self.emu.writememvalue(0xc3f8000c, 0x00000001, 4)
-        self.assertequal(self.emu.fmpll.f_pll(), 240000000.0)
+        # ESYNCR1[EMFD] = 80
+        # ESYNCR1[EPREDIV] = 7
+        self.emu.writeMemValue(0xC3F80008, 0xF0070050, 4)
+        # ESYNCR2[ERFD] = 1
+        self.emu.writeMemValue(0xC3F8000C, 0x00000001, 4)
+        self.assertEqual(self.emu.fmpll.f_pll(), 240000000.0)
 
-        # now set the siu peripheral configuration to allow the cpu frequency to
+        # Now set the SIU peripheral configuration to allow the CPU frequency to
         # be double the peripheral speed (otherwise the maximum bus/peripheral
-        # speed is 132 mhz
+        # speed is 132 MHz
 
-        # sysdiv[ipclkdiv] = 0
-        # sysdiv[bypass] = 1
-        self.emu.writememvalue(0xc3f909a0, 0x00000010, 4)
-        self.assertequal(self.emu.siu.f_periph(), 120000000.0)
+        # SYSDIV[IPCLKDIV] = 0
+        # SYSDIV[BYPASS] = 1
+        self.emu.writeMemValue(0xC3F909A0, 0x00000010, 4)
+        self.assertEqual(self.emu.siu.f_periph(), 120000000.0)
 
     def set_baudrates(self):
-        # configure fmpll to an appropriately reasonable example valid baud rate
+        # Configure FMPLL to an appropriately reasonable example valid baud rate
         self.set_sysclk_240mhz()
 
-        # set each peripheral to different sclk rates so we can test that the
+        # Set each peripheral to different sclk rates so we can test that the
         # emulated timer runs at an appropriately simulated rate.
-        ctrl_addrs = [a + flexcan_ctrl_offset for _, a in flexcan_devices]
+        ctrl_addrs = [a + FLEXCAN_CTRL_OFFSET for _, a in FLEXCAN_DEVICES]
 
-        # flexcan_a: 1 mbps
+        # FlexCAN_A: 1 Mbps
         #   - sclk = 120000000 / (14+1)
         #   - tq = sclk / (1 + (1+1) + (2+1) + (1+1))
-        val = (14 << flexcan_ctrl_presdiv_shift) | \
-                (2 << flexcan_ctrl_pseg1_shift) | \
-                (1 << flexcan_ctrl_pseg2_shift) | \
-                (flexcan_ctrl_clk_src_mask) | \
-                (1 << flexcan_ctrl_propseg_shift)
-        self.emu.writememvalue(ctrl_addrs[0], val, 4)
-        self.assertequal(self.emu.can[0].speed, 1000000)
+        val = (14 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
+                (2 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
+                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
+                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
+                (1 << FLEXCAN_CTRL_PROPSEG_SHIFT)
+        self.emu.writeMemValue(ctrl_addrs[0], val, 4)
+        self.assertEqual(self.emu.can[0].speed, 1000000)
 
-        # flexcan_b: 500 kbps
+        # FlexCAN_B: 500 kbps
         #   - sclk = 120000000 / (14+1)
         #   - tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-        val = (14 << flexcan_ctrl_presdiv_shift) | \
-                (7 << flexcan_ctrl_pseg1_shift) | \
-                (1 << flexcan_ctrl_pseg2_shift) | \
-                (flexcan_ctrl_clk_src_mask) | \
-                (4 << flexcan_ctrl_propseg_shift)
-        self.emu.writememvalue(ctrl_addrs[1], val, 4)
-        self.assertequal(self.emu.can[1].speed, 500000)
+        val = (14 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
+                (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
+                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
+                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
+                (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
+        self.emu.writeMemValue(ctrl_addrs[1], val, 4)
+        self.assertEqual(self.emu.can[1].speed, 500000)
 
-        #   flexcan_c: 250 kbps
+        #   FlexCAN_C: 250 kbps
         #   - sclk = 120000000 / (29+1)
         #   - tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-        val = (29 << flexcan_ctrl_presdiv_shift) | \
-                (7 << flexcan_ctrl_pseg1_shift) | \
-                (1 << flexcan_ctrl_pseg2_shift) | \
-                (flexcan_ctrl_clk_src_mask) | \
-                (4 << flexcan_ctrl_propseg_shift)
-        self.emu.writememvalue(ctrl_addrs[2], val, 4)
-        self.assertequal(self.emu.can[2].speed, 250000)
+        val = (29 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
+                (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
+                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
+                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
+                (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
+        self.emu.writeMemValue(ctrl_addrs[2], val, 4)
+        self.assertEqual(self.emu.can[2].speed, 250000)
 
-        # flexcan_d: 125 kbps
+        # FlexCAN_D: 125 kbps
         #   - sclk = 120000000 / (59+1)
         #   - tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-        val = (59 << flexcan_ctrl_presdiv_shift) | \
-                (7 << flexcan_ctrl_pseg1_shift) | \
-                (1 << flexcan_ctrl_pseg2_shift) | \
-                (flexcan_ctrl_clk_src_mask) | \
-                (4 << flexcan_ctrl_propseg_shift)
-        self.emu.writememvalue(ctrl_addrs[3], val, 4)
-        self.assertequal(self.emu.can[3].speed, 125000)
+        val = (59 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
+                (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
+                (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
+                (FLEXCAN_CTRL_CLK_SRC_MASK) | \
+                (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
+        self.emu.writeMemValue(ctrl_addrs[3], val, 4)
+        self.assertEqual(self.emu.can[3].speed, 125000)
 
     def test_flexcan_mcr_defaults(self):
         for idx in range(4):
-            devname, baseaddr = flexcan_devices[idx]
-            self.assertequal(self.emu.can[idx].devname, devname)
+            devname, baseaddr = FLEXCAN_DEVICES[idx]
+            self.assertEqual(self.emu.can[idx].devname, devname)
 
-            addr = baseaddr + flexcan_mcr_offset
+            addr = baseaddr + FLEXCAN_MCR_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), flexcan_mcr_default_bytes)
-            self.assertequal(self.emu.readmemvalue(addr, 4), flexcan_mcr_default)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.fen, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.soft_rst, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.supv, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.wrn_en, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.doze, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.srx_dis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mbfen, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.lprio_en, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.aen, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.idam, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.maxmb, 0x0f)
+            self.assertEqual(self.emu.readMemory(addr, 4), FLEXCAN_MCR_DEFAULT_BYTES)
+            self.assertEqual(self.emu.readMemValue(addr, 4), FLEXCAN_MCR_DEFAULT)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.fen, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.soft_rst, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.supv, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.wrn_en, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.doze, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.srx_dis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mbfen, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.lprio_en, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.aen, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.idam, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.maxmb, 0x0F)
 
     def test_flexcan_ctrl_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr = baseaddr + flexcan_ctrl_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr = baseaddr + FLEXCAN_CTRL_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.rjw, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.boff_msk, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.err_msk, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.twrn_msk, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.rwrn_msk, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.smp, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.boff_rec, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.tsyn, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lbuf, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.rjw, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.boff_msk, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.err_msk, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.twrn_msk, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.rwrn_msk, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.smp, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.boff_rec, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.tsyn, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lbuf, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
 
     def test_flexcan_timer_defaults(self):
-        test_addrs = [a + flexcan_timer_offset for _, a in flexcan_devices]
+        test_addrs = [a + FLEXCAN_TIMER_OFFSET for _, a in FLEXCAN_DEVICES]
         for addr in test_addrs:
-            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
 
-        # start the timer for each peripheral, ensure that the timer value has
-        # changed and that none of the other can device timers moved
+        # Start the timer for each peripheral, ensure that the timer value has
+        # changed and that none of the other CAN device timers moved
 
-        # can a
+        # CAN A
         self.emu.can[0]._timer.start()
         time.sleep(0.1)
-        self.assertnotequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertnotequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
+        self.assertNotEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertNotEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
 
-        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
 
         self.emu.can[0]._timer.stop()
-        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
 
-        # can b
+        # CAN B
         self.emu.can[1]._timer.start()
         time.sleep(0.1)
-        self.assertnotequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertnotequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
+        self.assertNotEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertNotEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
 
-        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
 
         self.emu.can[1]._timer.stop()
-        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
 
-        # can c
+        # CAN C
         self.emu.can[2]._timer.start()
         time.sleep(0.1)
-        self.assertnotequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertnotequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
+        self.assertNotEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertNotEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
 
-        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
 
         self.emu.can[2]._timer.stop()
-        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
 
-        # can d
+        # CAN D
         self.emu.can[3]._timer.start()
         time.sleep(0.1)
-        self.assertnotequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertnotequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
+        self.assertNotEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertNotEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
 
-        self.assertequal(self.emu.readmemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[0], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[1], 4), 0x00000000)
-        self.assertequal(self.emu.readmemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[2], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[0], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[0], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[1], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[1], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[2], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[2], 4), 0x00000000)
 
         self.emu.can[3]._timer.stop()
-        self.assertequal(self.emu.readmemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
-        self.assertequal(self.emu.readmemvalue(test_addrs[3], 4), 0x00000000)
+        self.assertEqual(self.emu.readMemory(test_addrs[3], 4), b'\x00\x00\x00\x00')
+        self.assertEqual(self.emu.readMemValue(test_addrs[3], 4), 0x00000000)
 
     def test_flexcan_rxgmask_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr = baseaddr + flexcan_rxgmask_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr = baseaddr + FLEXCAN_RXGMASK_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.rxgmask, 0xffffffff)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.rxgmask, 0xffffffff)
 
     def test_flexcan_rx14mask_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr = baseaddr + flexcan_rx14mask_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr = baseaddr + FLEXCAN_RX14MASK_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.rx14mask, 0xffffffff)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.rx14mask, 0xffffffff)
 
     def test_flexcan_rx15mask_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr = baseaddr + flexcan_rx15mask_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr = baseaddr + FLEXCAN_RX15MASK_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.rx15mask, 0xffffffff)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.rx15mask, 0xffffffff)
 
     def test_flexcan_ecr_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr = baseaddr + flexcan_ecr_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr = baseaddr + FLEXCAN_ECR_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.ecr.tx_err, 0)
-            self.assertequal(self.emu.can[idx].registers.ecr.rx_err, 0)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.ecr.tx_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.ecr.rx_err, 0)
 
     def test_flexcan_esr_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr = baseaddr + flexcan_esr_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr = baseaddr + FLEXCAN_ESR_OFFSET
 
-            self.assertequal(self.emu.readmemory(addr, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.esr.twrn_int, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.rwrn_int, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.bit1_err, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.bit0_err, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.ack_err, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.crc_err, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.frm_err, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.stf_err, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.tx_wrn, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.rx_wrn, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.idle, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.txrx, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.flt_conf, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.boff_int, 0)
-            self.assertequal(self.emu.can[idx].registers.esr.err_int, 0)
+            self.assertEqual(self.emu.readMemory(addr, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.esr.twrn_int, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.rwrn_int, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.bit1_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.bit0_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.ack_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.crc_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.frm_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.stf_err, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.tx_wrn, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.rx_wrn, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.idle, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.txrx, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.flt_conf, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.boff_int, 0)
+            self.assertEqual(self.emu.can[idx].registers.esr.err_int, 0)
 
     def test_flexcan_imask_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr1 = baseaddr + flexcan_imask1_offset
-            addr2 = baseaddr + flexcan_imask2_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr1 = baseaddr + FLEXCAN_IMASK1_OFFSET
+            addr2 = baseaddr + FLEXCAN_IMASK2_OFFSET
 
-            # imask1
-            self.assertequal(self.emu.readmemory(addr1, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.imask1, 0x00000000)
+            # IMASK1
+            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.imask1, 0x00000000)
 
-            self.emu.writememory(addr1, b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemory(addr1, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr1, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.imask1, 0xffffffff)
+            self.emu.writeMemory(addr1, b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemory(addr1, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr1, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.imask1, 0xffffffff)
 
-            # imask2
-            self.assertequal(self.emu.readmemory(addr2, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr2, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.imask2, 0x00000000)
+            # IMASK2
+            self.assertEqual(self.emu.readMemory(addr2, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr2, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.imask2, 0x00000000)
 
-            self.emu.writememory(addr2, b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemory(addr2, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr2, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.imask2, 0xffffffff)
+            self.emu.writeMemory(addr2, b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemory(addr2, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr2, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.imask2, 0xffffffff)
 
     def test_flexcan_iflag_defaults(self):
         for idx in range(4):
-            _, baseaddr = flexcan_devices[idx]
-            addr1 = baseaddr + flexcan_iflag1_offset
-            addr2 = baseaddr + flexcan_iflag2_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            addr1 = baseaddr + FLEXCAN_IFLAG1_OFFSET
+            addr2 = baseaddr + FLEXCAN_IFLAG2_OFFSET
 
-            # iflag1
-            self.assertequal(self.emu.readmemory(addr1, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.iflag1, 0x00000000)
+            # IFLAG1
+            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.iflag1, 0x00000000)
 
-            # ensure the flag1 register are w1c and can't be set by writing
-            self.emu.writememory(addr1, b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemory(addr1, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.iflag1, 0x00000000)
+            # Ensure the flag1 register are w1c and can't be set by writing
+            self.emu.writeMemory(addr1, b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.iflag1, 0x00000000)
 
-            self.emu.can[idx].registers.vsoverridevalue('iflag1', 0xffffffff)
+            self.emu.can[idx].registers.vsOverrideValue('iflag1', 0xffffffff)
 
-            self.assertequal(self.emu.readmemory(addr1, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr1, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.iflag1, 0xffffffff)
+            self.assertEqual(self.emu.readMemory(addr1, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr1, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.iflag1, 0xffffffff)
 
-            # clear some flags
-            self.emu.writememory(addr1, b'\xa5\xa5\xa5\xa5')
-            self.assertequal(self.emu.readmemory(addr1, 4), b'\x5a\x5a\x5a\x5a')
-            self.assertequal(self.emu.readmemvalue(addr1, 4), 0x5a5a5a5a)
-            self.assertequal(self.emu.can[idx].registers.iflag1, 0x5a5a5a5a)
+            # Clear some flags
+            self.emu.writeMemory(addr1, b'\xa5\xa5\xa5\xa5')
+            self.assertEqual(self.emu.readMemory(addr1, 4), b'\x5a\x5a\x5a\x5a')
+            self.assertEqual(self.emu.readMemValue(addr1, 4), 0x5a5a5a5a)
+            self.assertEqual(self.emu.can[idx].registers.iflag1, 0x5a5a5a5a)
 
-            # iflag2
-            self.assertequal(self.emu.readmemory(addr2, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr2, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.iflag2, 0x00000000)
+            # IFLAG2
+            self.assertEqual(self.emu.readMemory(addr2, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr2, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.iflag2, 0x00000000)
 
-            # ensure the flag2 register are w1c and can't be set by writing
-            self.emu.writememory(addr2, b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemory(addr2, 4), b'\x00\x00\x00\x00')
-            self.assertequal(self.emu.readmemvalue(addr2, 4), 0x00000000)
-            self.assertequal(self.emu.can[idx].registers.iflag2, 0x00000000)
+            # Ensure the flag2 register are w1c and can't be set by writing
+            self.emu.writeMemory(addr2, b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemory(addr2, 4), b'\x00\x00\x00\x00')
+            self.assertEqual(self.emu.readMemValue(addr2, 4), 0x00000000)
+            self.assertEqual(self.emu.can[idx].registers.iflag2, 0x00000000)
 
-            self.emu.can[idx].registers.vsoverridevalue('iflag2', 0xffffffff)
+            self.emu.can[idx].registers.vsOverrideValue('iflag2', 0xffffffff)
 
-            self.assertequal(self.emu.readmemory(addr2, 4), b'\xff\xff\xff\xff')
-            self.assertequal(self.emu.readmemvalue(addr2, 4), 0xffffffff)
-            self.assertequal(self.emu.can[idx].registers.iflag2, 0xffffffff)
+            self.assertEqual(self.emu.readMemory(addr2, 4), b'\xff\xff\xff\xff')
+            self.assertEqual(self.emu.readMemValue(addr2, 4), 0xffffffff)
+            self.assertEqual(self.emu.can[idx].registers.iflag2, 0xffffffff)
 
-            # clear some flags
-            self.emu.writememory(addr2, b'\x5a\x5a\x5a\x5a')
-            self.assertequal(self.emu.readmemory(addr2, 4), b'\xa5\xa5\xa5\xa5')
-            self.assertequal(self.emu.readmemvalue(addr2, 4), 0xa5a5a5a5)
-            self.assertequal(self.emu.can[idx].registers.iflag2, 0xa5a5a5a5)
+            # Clear some flags
+            self.emu.writeMemory(addr2, b'\x5a\x5a\x5a\x5a')
+            self.assertEqual(self.emu.readMemory(addr2, 4), b'\xa5\xa5\xa5\xa5')
+            self.assertEqual(self.emu.readMemValue(addr2, 4), 0xa5a5a5a5)
+            self.assertEqual(self.emu.can[idx].registers.iflag2, 0xa5a5a5a5)
 
     def test_flexcan_modes(self):
         for idx in range(4):
-            devname, baseaddr = flexcan_devices[idx]
-            self.assertequal(self.emu.can[idx].devname, devname)
+            devname, baseaddr = FLEXCAN_DEVICES[idx]
+            self.assertEqual(self.emu.can[idx].devname, devname)
 
-            mcr_addr = baseaddr + flexcan_mcr_offset
-            ctrl_addr = baseaddr + flexcan_ctrl_offset
+            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
+            ctrl_addr = baseaddr + FLEXCAN_CTRL_OFFSET
 
-            # should start off in disable, but the mcr[mdis] bit isn't set
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.disable)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            # Should start off in DISABLE, but the MCR[MDIS] bit isn't set
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.DISABLE)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # writing the same value back to mcr should put the peripheral into
-            # freeze, mcr[mdisack] should now be cleared
-            mcr_val = self.emu.readmemvalue(mcr_addr, 4)
-            self.emu.writememvalue(mcr_addr, mcr_val, 4)
+            # Writing the same value back to MCR should put the peripheral into
+            # FREEZE, MCR[MDISACK] should now be cleared
+            mcr_val = self.emu.readMemValue(mcr_addr, 4)
+            self.emu.writeMemValue(mcr_addr, mcr_val, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # writing only the frz and halt bits should result in no change
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
+            # Writing only the FRZ and HALT bits should result in no change
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # clearing the mcr[halt] bit should move the device to normal mode
-            # and clear mcr[not_rdy] and mcr[frz_ack]
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask, 4)
+            # Clearing the MCR[HALT] bit should move the device to NORMAL mode
+            # and clear MCR[NOT_RDY] and MCR[FRZ_ACK]
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # set mcr[mdis] to move back to disabled, this should also set
-            # mcr[not_rdy] and mcr[mdisack]
+            # Set MCR[MDIS] to move back to disabled, this should also set
+            # MCR[NOT_RDY] and MCR[MDISACK]
             #
-            # mcr[frz] is also cleared by this change because the frz mask is
+            # MCR[FRZ] is also cleared by this change because the FRZ mask is
             # not written in this step.
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_mdis_mask, 4)
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_MDIS_MASK, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.disable)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.DISABLE)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # clearing mcr[mdis] moves back to normal
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            # Clearing MCR[MDIS] moves back to NORMAL
+            self.emu.writeMemValue(mcr_addr, 0, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # setting only mcr[halt] should not change anything since the
-            # mcr[frz] bit is not set.
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_halt_mask, 4)
+            # Setting only MCR[HALT] should not change anything since the
+            # MCR[FRZ] bit is not set.
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_HALT_MASK, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # setting both halt and frz moves the device back to freeze
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
+            # Setting both HALT and FRZ moves the device back to FREEZE
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 1)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 1)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # test out loopback and listen-only modes but first move to freeze.
+            # Test out loopback and listen-only modes but first move to FREEZE.
             # this step isn't currently necessary but it is the more "correct"
             # way to change modes.
 
-            # setting ctrl[lpb] should enable loopback mode once the device is
-            # back to normal mode.
-            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_lpb_mask, 4)
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            # Setting CTRL[LPB] should enable loopback mode once the device is
+            # back to NORMAL mode.
+            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_LPB_MASK, 4)
+            self.emu.writeMemValue(mcr_addr, 0, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.loop_back)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 0)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.LOOP_BACK)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 0)
 
-            # back to freeze
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
+            # Back to FREEZE
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
 
-            # setting lom and lpb should listen-only mode once the device is
-            # back to normal mode.
-            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_lpb_mask | flexcan_ctrl_lom_mask, 4)
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            # Setting LOM and LPB should listen-only mode once the device is
+            # back to NORMAL mode.
+            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_LPB_MASK | FLEXCAN_CTRL_LOM_MASK, 4)
+            self.emu.writeMemValue(mcr_addr, 0, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.listen_only)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 1)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.LISTEN_ONLY)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 1)
 
-            # back to freeze
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.freeze)
+            # Back to FREEZE
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.FREEZE)
 
-            # setting lom will also set the device to listen-only mode
-            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_lom_mask, 4)
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            # Setting LOM will also set the device to listen-only mode
+            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_LOM_MASK, 4)
+            self.emu.writeMemValue(mcr_addr, 0, 4)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.listen_only)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdis, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.halt, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.not_rdy, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.frz_ack, 0)
-            self.assertequal(self.emu.can[idx].registers.mcr.mdisack, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lpb, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.lom, 1)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.LISTEN_ONLY)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdis, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.halt, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.not_rdy, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.frz_ack, 0)
+            self.assertEqual(self.emu.can[idx].registers.mcr.mdisack, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lpb, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.lom, 1)
 
     def test_flexcan_speed(self):
         for idx in range(4):
-            devname, baseaddr = flexcan_devices[idx]
-            self.assertequal(self.emu.can[idx].devname, devname)
-            ctrl_addr = baseaddr + flexcan_ctrl_offset
+            devname, baseaddr = FLEXCAN_DEVICES[idx]
+            self.assertEqual(self.emu.can[idx].devname, devname)
+            ctrl_addr = baseaddr + FLEXCAN_CTRL_OFFSET
 
-            # with the default clock source of extal, and presdiv the sclk is
-            # 40 mhz, and then the default bitrate is 10 mbit/sec
-            self.assertequal(self.emu.can[idx].speed, 10000000)
-            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
+            # With the default clock source of EXTAL, and PRESDIV the SCLK is
+            # 40 MHz, and then the default bitrate is 10 Mbit/sec
+            self.assertEqual(self.emu.can[idx].speed, 10000000)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
 
-            # with clock source of the bus/internal pll, and presdiv the sclk is
-            # 30 mhz, and then the default bitrate is 7.5 mbit/sec
-            self.emu.writememvalue(ctrl_addr, flexcan_ctrl_clk_src_mask, 4)
-            self.assertequal(self.emu.can[idx].speed, 7500000)
-            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
+            # With clock source of the bus/internal PLL, and PRESDIV the SCLK is
+            # 30 MHz, and then the default bitrate is 7.5 Mbit/sec
+            self.emu.writeMemValue(ctrl_addr, FLEXCAN_CTRL_CLK_SRC_MASK, 4)
+            self.assertEqual(self.emu.can[idx].speed, 7500000)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
 
-        # configure fmpll to an appropriately reasonable example valid baud rate
+        # Configure FMPLL to an appropriately reasonable example valid baud rate
         self.set_sysclk_240mhz()
 
         for idx in range(4):
-            # force the can device to update the clock speed
-            self.emu.can[idx].updatespeed()
+            # Force the CAN device to update the clock speed
+            self.emu.can[idx].updateSpeed()
 
-            _, baseaddr = flexcan_devices[idx]
-            ctrl_addr = baseaddr + flexcan_ctrl_offset
+            _, baseaddr = FLEXCAN_DEVICES[idx]
+            ctrl_addr = baseaddr + FLEXCAN_CTRL_OFFSET
 
-            # with clock source of the bus/internal pll, and presdiv the sclk is
-            # 120 mhz, and then the default bitrate is 30 mbit/sec
-            self.assertequal(self.emu.can[idx].speed, 30000000)
-            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 0)
-            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 0)
+            # With clock source of the bus/internal PLL, and PRESDIV the SCLK is
+            # 120 MHz, and then the default bitrate is 30 Mbit/sec
+            self.assertEqual(self.emu.can[idx].speed, 30000000)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 0)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 0)
 
-            # a baudrate of 250000 can be achieved in a few ways, but one way
+            # A baudrate of 250000 can be achieved in a few ways, but one way
             # is:
             #   sclk = 120000000 / (29+1)
             #   tq = sclk / (1 + (4+1) + (7+1) + (1+1))
-            val = (29 << flexcan_ctrl_presdiv_shift) | \
-                    (7 << flexcan_ctrl_pseg1_shift) | \
-                    (1 << flexcan_ctrl_pseg2_shift) | \
-                    (flexcan_ctrl_clk_src_mask) | \
-                    (4 << flexcan_ctrl_propseg_shift)
-            self.emu.writememvalue(ctrl_addr, val, 4)
+            val = (29 << FLEXCAN_CTRL_PRESDIV_SHIFT) | \
+                    (7 << FLEXCAN_CTRL_PSEG1_SHIFT) | \
+                    (1 << FLEXCAN_CTRL_PSEG2_SHIFT) | \
+                    (FLEXCAN_CTRL_CLK_SRC_MASK) | \
+                    (4 << FLEXCAN_CTRL_PROPSEG_SHIFT)
+            self.emu.writeMemValue(ctrl_addr, val, 4)
 
-            # - ctrl[clk_src] set, the bus/internal pll
-            # - ctrl[presdiv] is 29
-            # - ctrl[pseg1] is 7
-            # - ctrl[pseg2] is 1
-            # - ctrl[propseg] is 4
-            # sclk is 4 mhz, and the bitrate (tq) is 250000 kbit/sec
-            self.assertequal(self.emu.can[idx].speed, 250000)
-            self.assertequal(self.emu.can[idx].registers.ctrl.presdiv, 29)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg1, 7)
-            self.assertequal(self.emu.can[idx].registers.ctrl.pseg2, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.clk_src, 1)
-            self.assertequal(self.emu.can[idx].registers.ctrl.propseg, 4)
+            # - CTRL[CLK_SRC] set, the bus/internal PLL
+            # - CTRL[PRESDIV] is 29
+            # - CTRL[PSEG1] is 7
+            # - CTRL[PSEG2] is 1
+            # - CTRL[PROPSEG] is 4
+            # SCLK is 4 MHz, and the bitrate (tq) is 250000 Kbit/sec
+            self.assertEqual(self.emu.can[idx].speed, 250000)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.presdiv, 29)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg1, 7)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.pseg2, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.clk_src, 1)
+            self.assertEqual(self.emu.can[idx].registers.ctrl.propseg, 4)
 
     def test_flexcan_timer(self):
-        # because this test attempts to test the accuracy of emulated timers
+        # Because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # set standard bus speeds
+        # Set standard bus speeds
         self.set_baudrates()
 
-        # at 1mbps run for 0.05 msec can a should have a value of approximately
-        # 50000. since the scaling time for this test is set to 0.1 set each
-        # bus to normal and then wait 0.5 seconds before collecting the end
+        # at 1Mbps run for 0.05 msec CAN A should have a value of approximately
+        # 50000. Since the scaling time for this test is set to 0.1 set each
+        # bus to NORMAL and then wait 0.5 seconds before collecting the end
         # timer values.
         for idx in range(4):
-            devname, baseaddr = flexcan_devices[idx]
-            mcr_addr = baseaddr + flexcan_mcr_offset
-            timer_addr = baseaddr + flexcan_timer_offset
+            devname, baseaddr = FLEXCAN_DEVICES[idx]
+            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
+            timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
 
-            # expected ticks:
+            # Expected ticks:
             expected_val = self.emu.can[idx].speed * 0.5 * self.emu._systime_scaling
 
-            # margin of error is approximately 0.001 (so speed * 0.001 * 0.1)
-            # because this is dependant on the execution speed of the machine in
+            # Margin of error is approximately 0.001 (so speed * 0.001 * 0.1)
+            # Because this is Dependant on the execution speed of the machine in
             # question increase to 0.005
             margin = self.emu.can[idx].speed * 0.005 * self.emu._systime_scaling
 
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            self.emu.writeMemValue(mcr_addr, 0, 4)
 
             time.sleep(0.5)
-            val = self.emu.readmemvalue(timer_addr, 4)
+            val = self.emu.readMemValue(timer_addr, 4)
 
-            self.assertalmostequal(val, expected_val, delta=margin, msg=devname)
+            self.assertAlmostEqual(val, expected_val, delta=margin, msg=devname)
 
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.normal, devname)
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_mdis_mask, 4)
-            self.assertequal(self.emu.can[idx].mode, flexcan.flexcan_mode.disable, devname)
-            self.assertequal(self.emu.readmemvalue(timer_addr, 4), 0, devname)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.NORMAL, devname)
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_MDIS_MASK, 4)
+            self.assertEqual(self.emu.can[idx].mode, flexcan.FLEXCAN_MODE.DISABLE, devname)
+            self.assertEqual(self.emu.readMemValue(timer_addr, 4), 0, devname)
 
     def test_flexcan_tx(self):
-        # because this test attempts to test the accuracy of emulated timers
+        # Because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # set standard bus speeds
+        # Set standard bus speeds
         self.set_baudrates()
 
-        # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+        # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
         enabled_intrs = list(range(0, 8)) + list(range(24, 32)) + list(range(32, 48))
 
-        # send a message from each bus and ensure the timestamp is correctly
+        # Send a message from each bus and ensure the timestamp is correctly
         # updated, wait 0.10 seconds before sending and then check that the time
         # stamp is correct.
         for dev in range(4):
-            devname, baseaddr = flexcan_devices[dev]
-            mcr_addr = baseaddr + flexcan_mcr_offset
-            timer_addr = baseaddr + flexcan_timer_offset
+            devname, baseaddr = FLEXCAN_DEVICES[dev]
+            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
+            timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
 
-            # generate one message for each mailbox
-            msgs = [generate_msg() for i in range(flexcan_num_mbs)]
+            # Generate one message for each mailbox
+            msgs = [generate_msg() for i in range(FLEXCAN_NUM_MBs)]
 
-            # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
-            imask1_val = 0xff0000ff
-            imask2_val = 0x0000ffff
-            self.emu.writememvalue(baseaddr + flexcan_imask1_offset, imask1_val, 4)
-            self.emu.writememvalue(baseaddr + flexcan_imask2_offset, imask2_val, 4)
+            # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+            imask1_val = 0xFF0000FF
+            imask2_val = 0x0000FFFF
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK1_OFFSET, imask1_val, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK2_OFFSET, imask2_val, 4)
 
-            # change mode to normal, the timer now starts moving, but disable
+            # Change mode to NORMAL, the timer now starts moving, but disable
             # self-reception of messages to make this test simpler
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_srx_dis_mask, 4)
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_SRX_DIS_MASK, 4)
             start_time = time.time()
 
-            # place messages into each mailbox and mark the mailbox as inactive
-            for mb in range(flexcan_num_mbs):
-                # generate a random priority (0 to 7) to ensure that the
+            # Place messages into each mailbox and mark the mailbox as inactive
+            for mb in range(FLEXCAN_NUM_MBs):
+                # Generate a random priority (0 to 7) to ensure that the
                 # priority field is correctly removed during transmission
                 prio = random.randrange(0, 8)
-                data = msgs[mb].encode(code=flexcan.flexcan_code_tx_inactive, prio=prio)
+                data = msgs[mb].encode(code=flexcan.FLEXCAN_CODE_TX_INACTIVE, prio=prio)
                 write_mb_data(self.emu, dev, mb, data)
 
-                # ensure that the written data matches what should have been
+                # Ensure that the written data matches what should have been
                 # written
                 testmsg = '%s[%d]' % (devname, mb)
-                start = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
-                self.assertequal(self.emu.readmemory(start, flexcan_mbx_size), data, msg=testmsg)
+                start = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                self.assertEqual(self.emu.readMemory(start, FLEXCAN_MBx_SIZE), data, msg=testmsg)
 
-            # ensure that no messages have been transmitted and there are no
+            # Ensure that no messages have been transmitted and there are no
             # pending interrupts
-            self.assertequal(self.emu.can[dev].gettransmittedobjs(), [], devname)
-            self.assertequal(self._getpendingexceptions(), [], msg=devname)
+            self.assertEqual(self.emu.can[dev].getTransmittedObjs(), [], devname)
+            self.assertEqual(self._getPendingExceptions(), [], msg=devname)
 
-            # wait some short time to let the timer run for a bit
+            # Wait some short time to let the timer run for a bit
             time.sleep(0.5)
 
-            # for each can device only transmit from some of them:
-            #   can a: tx in all mailboxes
-            #   can b: tx in every other mailbox
-            #   can c: tx in every third mailbox
-            #   can d: tx in every fourth mailbox
-            tx_mbs = list(range(0, flexcan_num_mbs, dev+1))
+            # For each CAN device only transmit from some of them:
+            #   CAN A: tx in all mailboxes
+            #   CAN B: tx in every other mailbox
+            #   CAN C: tx in every third mailbox
+            #   CAN D: tx in every fourth mailbox
+            tx_mbs = list(range(0, FLEXCAN_NUM_MBs, dev+1))
 
             # temporarily disable the garbage collector
             gc.disable()
 
-            # randomize the tx mailbox order now
+            # Randomize the tx mailbox order now
             random.shuffle(tx_mbs)
             tx_times = {}
             for mb in tx_mbs:
-                # save the timestamp that the message was sent
-                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
-                self.emu.writememvalue(addr, flexcan.flexcan_code_tx_active, 1)
+                # Save the timestamp that the message was sent
+                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                self.emu.writeMemValue(addr, flexcan.FLEXCAN_CODE_TX_ACTIVE, 1)
                 tx_times[mb] = time.time()
 
             # it can be re-enabled now
             gc.enable()
 
-            # now read all queued transmit messages
-            txd_msgs = self.emu.can[dev].gettransmittedobjs()
-            self.assertequal(len(txd_msgs), len(tx_mbs), msg=devname)
+            # Now read all queued transmit messages
+            txd_msgs = self.emu.can[dev].getTransmittedObjs()
+            self.assertEqual(len(txd_msgs), len(tx_mbs), msg=devname)
 
-            # ensure the correct iflags are set
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            iflag2_val = self.emu.readmemvalue(baseaddr + flexcan_iflag2_offset, 4)
+            # Ensure the correct IFLAGs are set
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            iflag2_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG2_OFFSET, 4)
 
             if dev == 0:
-                # for can a every mailbox should have sent a message
-                self.assertequal(iflag1_val, 0xffffffff, msg=devname)
-                self.assertequal(iflag2_val, 0xffffffff, msg=devname)
+                # For CAN A every mailbox should have sent a message
+                self.assertEqual(iflag1_val, 0xFFFFFFFF, msg=devname)
+                self.assertEqual(iflag2_val, 0xFFFFFFFF, msg=devname)
             elif dev == 1:
-                # for can b every other mailbox should have sent a message
-                self.assertequal(iflag1_val, 0x55555555, msg=devname)
-                self.assertequal(iflag2_val, 0x55555555, msg=devname)
+                # For CAN B every other mailbox should have sent a message
+                self.assertEqual(iflag1_val, 0x55555555, msg=devname)
+                self.assertEqual(iflag2_val, 0x55555555, msg=devname)
             elif dev == 2:
-                # for can c every third mailbox should have sent a message
-                self.assertequal(iflag1_val, 0x49249249, msg=devname)
-                self.assertequal(iflag2_val, 0x92492492, msg=devname)
+                # For CAN C every third mailbox should have sent a message
+                self.assertEqual(iflag1_val, 0x49249249, msg=devname)
+                self.assertEqual(iflag2_val, 0x92492492, msg=devname)
             elif dev == 3:
-                # for can d every fourth mailbox should have sent a message
-                self.assertequal(iflag1_val, 0x11111111, msg=devname)
-                self.assertequal(iflag2_val, 0x11111111, msg=devname)
+                # For CAN D every fourth mailbox should have sent a message
+                self.assertEqual(iflag1_val, 0x11111111, msg=devname)
+                self.assertEqual(iflag2_val, 0x11111111, msg=devname)
 
             # calculate how many interrupts there should be and correlate the
-            # interrupts to the transmit and interrupt enabled mailboxes
+            # interrupts to the transmit AND interrupt enabled mailboxes
             tx_int_mbs = []
-            for mb in range(flexcan_num_mbs):
+            for mb in range(FLEXCAN_NUM_MBs):
                 testmsg = '%s[%d]' % (devname, mb)
                 if mb < 32:
                     mb_mask = 1 << mb
@@ -952,154 +952,154 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
                     mask = imask2_val
 
                 if flag & mb_mask:
-                    self.assertin(mb, tx_mbs, msg=testmsg)
+                    self.assertIn(mb, tx_mbs, msg=testmsg)
                     if mask & mb_mask:
                         tx_int_mbs.append(mb)
                 else:
-                    self.assertnotin(mb, tx_mbs, msg=testmsg)
+                    self.assertNotIn(mb, tx_mbs, msg=testmsg)
 
-            # it is expected that the calculated timestamp will be slightly
+            # It is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
             margin = self.emu.can[dev].speed * 0.0100 * self.emu._systime_scaling
 
-            # confirm that the order of the generated interrupts matches both
+            # Confirm that the order of the generated interrupts matches both
             # the order of the transmitted messages and the interrupt source for
-            # the tx mailbox
-            excs = self._getpendingexceptions()
-            self.assertequal(len(excs), len(tx_int_mbs), msg=devname)
+            # the Tx mailbox
+            excs = self._getPendingExceptions()
+            self.assertEqual(len(excs), len(tx_int_mbs), msg=devname)
             exc_iter = iter(excs)
             txd_msgs_iter = iter(txd_msgs)
 
-            # iterate through the mailboxes based on the order messages were
+            # Iterate through the mailboxes based on the order messages were
             # transmitted
             for mb in tx_mbs:
                 testmsg = '%s[%d]' % (devname, mb)
 
-                # confirm that the message contents are correct
+                # Confirm that the message contents are correct
                 txd_msg = next(txd_msgs_iter)
-                self.assertequal(txd_msg, msgs[mb], msg=testmsg)
+                self.assertEqual(txd_msg, msgs[mb], msg=testmsg)
 
-                # confirm that the timestamp is accurate
+                # Confirm that the timestamp is accurate
                 tx_delay = tx_times[mb] - start_time
-                expected_ticks = int(self.emu.can[dev].speed * tx_delay * self.emu._systime_scaling) & 0xffff
+                expected_ticks = int(self.emu.can[dev].speed * tx_delay * self.emu._systime_scaling) & 0xFFFF
 
-                ts_offset = (mb * flexcan_mbx_size) + 2
-                timestamp = struct.unpack_from('>h', self.emu.can[dev].registers.mb.value, ts_offset)[0]
+                ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
+                timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
 
-                self.assertalmostequal(timestamp, expected_ticks, delta=margin, msg=testmsg)
+                self.assertAlmostEqual(timestamp, expected_ticks, delta=margin, msg=testmsg)
 
-                # lastly, a mailbox should only have a corresponding interrupt
+                # Lastly, a mailbox should only have a corresponding interrupt
                 # if the interrupt mask is set
                 if mb in tx_int_mbs:
-                    self.assertequal(next(exc_iter), get_int(dev, mb), msg=testmsg)
+                    self.assertEqual(next(exc_iter), get_int(dev, mb), msg=testmsg)
 
-            # now ensure that all mailboxes that were not in the list are still
+            # Now ensure that all mailboxes that were not in the list are still
             # inactive
-            for mb in range(flexcan_num_mbs):
+            for mb in range(FLEXCAN_NUM_MBs):
                 if mb not in tx_mbs:
                     testmsg = '%s[%d]' % (devname, mb)
 
-                    # ensure that inactive mailboxes have the same data and
-                    # still have a code of tx_inactive, and the timestamp is
+                    # Ensure that inactive mailboxes have the same data and
+                    # still have a CODE of TX_INACTIVE, and the TIMESTAMP is
                     # still 0
-                    code_offset = mb * flexcan_mbx_size
+                    code_offset = mb * FLEXCAN_MBx_SIZE
                     code = self.emu.can[dev].registers.mb[code_offset]
-                    self.assertequal(code, flexcan.flexcan_code_tx_inactive, msg=testmsg)
-                    code_addr = baseaddr + flexcan_mb_offset + code_offset
-                    self.assertequal(self.emu.readmemvalue(code_addr, 1),
-                            flexcan.flexcan_code_tx_inactive, msg=testmsg)
+                    self.assertEqual(code, flexcan.FLEXCAN_CODE_TX_INACTIVE, msg=testmsg)
+                    code_addr = baseaddr + FLEXCAN_MB_OFFSET + code_offset
+                    self.assertEqual(self.emu.readMemValue(code_addr, 1),
+                            flexcan.FLEXCAN_CODE_TX_INACTIVE, msg=testmsg)
 
-                    ts_offset = (mb * flexcan_mbx_size) + 2
-                    timestamp = struct.unpack_from('>h', self.emu.can[dev].registers.mb.value, ts_offset)[0]
-                    self.assertequal(timestamp, 0, msg=testmsg)
-                    ts_addr = baseaddr + flexcan_mb_offset + ts_offset
-                    self.assertequal(self.emu.readmemvalue(ts_addr, 2), 0, msg=testmsg)
+                    ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
+                    timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
+                    self.assertEqual(timestamp, 0, msg=testmsg)
+                    ts_addr = baseaddr + FLEXCAN_MB_OFFSET + ts_offset
+                    self.assertEqual(self.emu.readMemValue(ts_addr, 2), 0, msg=testmsg)
 
     def test_flexcan_rx(self):
-        # because this test attempts to test the accuracy of emulated timers
+        # Because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # set standard bus speeds
+        # Set standard bus speeds
         self.set_baudrates()
 
-        # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+        # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
         enabled_intrs = list(range(0, 8)) + list(range(24, 32)) + list(range(32, 48))
 
-        # send a message from each bus and ensure the timestamp is correctly
+        # Send a message from each bus and ensure the timestamp is correctly
         # updated, wait 0.10 seconds before sending and then check that the time
         # stamp is correct.
 
         for dev in range(4):
-            devname, baseaddr = flexcan_devices[dev]
-            mcr_addr = baseaddr + flexcan_mcr_offset
-            timer_addr = baseaddr + flexcan_timer_offset
+            devname, baseaddr = FLEXCAN_DEVICES[dev]
+            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
+            timer_addr = baseaddr + FLEXCAN_TIMER_OFFSET
 
-            # for each can device only enable some mailboxes to receive:
-            #   can a: rx in all mailboxes
-            #   can b: rx in every other mailbox
-            #   can c: rx in every third mailbox
-            #   can d: rx in every fourth mailbox
-            # set those mailboxes to rx_empty now
-            rx_mbs = list(range(0, flexcan_num_mbs, dev+1))
+            # For each CAN device only enable some mailboxes to receive:
+            #   CAN A: rx in all mailboxes
+            #   CAN B: rx in every other mailbox
+            #   CAN C: rx in every third mailbox
+            #   CAN D: rx in every fourth mailbox
+            # Set those mailboxes to RX_EMPTY now
+            rx_mbs = list(range(0, FLEXCAN_NUM_MBs, dev+1))
             for mb in rx_mbs:
-                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
-                self.emu.writememvalue(addr, flexcan.flexcan_code_rx_empty, 1)
+                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                self.emu.writeMemValue(addr, flexcan.FLEXCAN_CODE_RX_EMPTY, 1)
 
-            # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
-            self.emu.writememvalue(baseaddr + flexcan_imask1_offset, 0xff0000ff, 4)
-            self.emu.writememvalue(baseaddr + flexcan_imask2_offset, 0x0000ffff, 4)
+            # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK1_OFFSET, 0xFF0000FF, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK2_OFFSET, 0x0000FFFF, 4)
 
-            # generate one message for each mailbox that can receive, because a
-            # message with id 0 would match a mailbox with the entire mask set
-            # and the filter value of 0, make the minimum id 1
+            # Generate one message for each mailbox that can receive, because a
+            # message with ID 0 would match a mailbox with the entire mask set
+            # and the filter value of 0, make the minimum ID 1
             msgs = [generate_msg(rtr=0, min_id=1) for i in range(len(rx_mbs))]
 
-            # change mode to normal
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            # Change mode to NORMAL
+            self.emu.writeMemValue(mcr_addr, 0, 4)
 
-            # call the processreceiveddata function to mimic what the emulator
-            # calls when a message is received during normal execution.  because
-            # the default filters are all 1's and no id masks were defined in
+            # Call the processReceivedData function to mimic what the emulator
+            # calls when a message is received during normal execution.  Because
+            # the default filters are all 1's and no ID masks were defined in
             # any of the valid receive mailboxes, these messages should all just
             # be discarded.
             for mb, msg in zip(rx_mbs, msgs):
-                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
-                self.emu.can[dev].processreceiveddata(msg)
+                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                self.emu.can[dev].processReceivedData(msg)
 
-            # loop through the mailboxes and ensure they are all still empty.
-            inactive_mb = b'\x00' * flexcan_mbx_size
-            empty_mb = b'\x04' + b'\x00' * (flexcan_mbx_size - 1)
-            for mb in range(flexcan_num_mbs):
+            # Loop through the mailboxes and ensure they are all still empty.
+            inactive_mb = b'\x00' * FLEXCAN_MBx_SIZE
+            empty_mb = b'\x04' + b'\x00' * (FLEXCAN_MBx_SIZE - 1)
+            for mb in range(FLEXCAN_NUM_MBs):
                 testmsg = '%s[%d]' % (devname, mb)
-                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
-                # ensure that nothing has been received in this mailbox, but the
-                # code is still correct
+                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                # Ensure that nothing has been received in this mailbox, but the
+                # CODE is still correct
                 if mb in rx_mbs:
-                    self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), empty_mb, msg=testmsg)
+                    self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), empty_mb, msg=testmsg)
                 else:
-                    self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), inactive_mb, msg=testmsg)
+                    self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), inactive_mb, msg=testmsg)
 
-            # ensure there are no pending interrupts
-            self.assertequal(self._getpendingexceptions(), [], msg=devname)
+            # Ensure there are no pending interrupts
+            self.assertEqual(self._getPendingExceptions(), [], msg=devname)
 
-            # now clear out the rxg, rx14, and rx15 masks, these must be changed
-            # in freeze mode
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_frz_mask | flexcan_mcr_halt_mask, 4)
-            self.emu.writememvalue(baseaddr + flexcan_rxgmask_offset, 0, 4)
-            self.emu.writememvalue(baseaddr + flexcan_rx14mask_offset, 0, 4)
-            self.emu.writememvalue(baseaddr + flexcan_rx15mask_offset, 0, 4)
+            # Now clear out the RXG, RX14, and RX15 masks, these must be changed
+            # in FREEZE mode
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FRZ_MASK | FLEXCAN_MCR_HALT_MASK, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_RXGMASK_OFFSET, 0, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_RX14MASK_OFFSET, 0, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_RX15MASK_OFFSET, 0, 4)
 
-            # now move back to normal mode
-            self.emu.writememvalue(mcr_addr, 0, 4)
+            # Now move back to normal mode
+            self.emu.writeMemValue(mcr_addr, 0, 4)
             start_time = time.time()
 
-            last_mb = none
-            last_timestamp = none
+            last_mb = None
+            last_timestamp = None
 
-            # it is expected that the calculated timestamp will be slightly
+            # It is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
             margin = self.emu.can[dev].speed * 0.0050 * self.emu._systime_scaling
@@ -1107,137 +1107,137 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # temporarily disable the garbage collector
             gc.disable()
 
-            # call the processreceiveddata function to mimic what the emulator
-            # calls when a message is received during normal execution.  because
+            # Call the processReceivedData function to mimic what the emulator
+            # calls when a message is received during normal execution.  Because
             # no filtering or masking is set up the messages should be placed
             # into the first empty mailbox
             for mb, msg in zip(rx_mbs, msgs):
                 testmsg = '%s[%d]' % (devname, mb)
-                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
 
-                self.emu.can[dev].processreceiveddata(msg)
+                self.emu.can[dev].processReceivedData(msg)
 
-                # confirm that the timestamp is accurate. the timer has probably
+                # Confirm that the timestamp is accurate. The timer has probably
                 # wrapped by now so ensure it is limited to 16 bits
                 rx_delay = time.time() - start_time
-                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xffff
+                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xFFFF
 
-                ts_offset = (mb * flexcan_mbx_size) + 2
-                timestamp = struct.unpack_from('>h', self.emu.can[dev].registers.mb.value, ts_offset)[0]
-                self.assertalmostequal(timestamp, expected_ticks, delta=margin, msg=testmsg)
+                ts_offset = (mb * FLEXCAN_MBx_SIZE) + 2
+                timestamp = struct.unpack_from('>H', self.emu.can[dev].registers.mb.value, ts_offset)[0]
+                self.assertAlmostEqual(timestamp, expected_ticks, delta=margin, msg=testmsg)
 
                 last_mb = mb
                 last_timestamp = timestamp
 
-                # now that the timestamp has been confirmed to be within the
+                # Now that the timestamp has been confirmed to be within the
                 # expected range, ensure that the message in the mailbox matches
                 # what is expected for the received message
-                rx_msg_data = msg.encode(code=flexcan.flexcan_code_rx_full, timestamp=timestamp)
-                self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), rx_msg_data, msg=testmsg)
+                rx_msg_data = msg.encode(code=flexcan.FLEXCAN_CODE_RX_FULL, timestamp=timestamp)
+                self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), rx_msg_data, msg=testmsg)
 
-                # ensure that there is a pending interrupt for this mailbox
+                # Ensure that there is a pending interrupt for this mailbox
                 if mb in enabled_intrs:
-                    self.assertequal(self._getpendingexceptions(), [get_int(dev, mb)], msg=testmsg)
+                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, mb)], msg=testmsg)
                 else:
-                    self.assertequal(self._getpendingexceptions(), [], msg=testmsg)
+                    self.assertEqual(self._getPendingExceptions(), [], msg=testmsg)
 
             # it can be re-enabled now
             gc.enable()
 
-            # there should be no more interrupts pending
-            self.assertequal(self._getpendingexceptions(), [], msg=testmsg)
+            # There should be no more interrupts pending
+            self.assertEqual(self._getPendingExceptions(), [], msg=testmsg)
 
-            # ensure the correct iflags are set
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            iflag2_val = self.emu.readmemvalue(baseaddr + flexcan_iflag2_offset, 4)
+            # Ensure the correct IFLAGs are set
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            iflag2_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG2_OFFSET, 4)
             if dev == 0:
-                # for can a every mailbox should have a message
-                self.assertequal(iflag1_val, 0xffffffff, msg=devname)
-                self.assertequal(iflag2_val, 0xffffffff, msg=devname)
+                # For CAN A every mailbox should have a message
+                self.assertEqual(iflag1_val, 0xFFFFFFFF, msg=devname)
+                self.assertEqual(iflag2_val, 0xFFFFFFFF, msg=devname)
             elif dev == 1:
-                # for can b every other mailbox should have a message
-                self.assertequal(iflag1_val, 0x55555555, msg=devname)
-                self.assertequal(iflag2_val, 0x55555555, msg=devname)
+                # For CAN B every other mailbox should have a message
+                self.assertEqual(iflag1_val, 0x55555555, msg=devname)
+                self.assertEqual(iflag2_val, 0x55555555, msg=devname)
             elif dev == 2:
-                # for can c every third mailbox should have a message
-                self.assertequal(iflag1_val, 0x49249249, msg=devname)
-                self.assertequal(iflag2_val, 0x92492492, msg=devname)
+                # For CAN C every third mailbox should have a message
+                self.assertEqual(iflag1_val, 0x49249249, msg=devname)
+                self.assertEqual(iflag2_val, 0x92492492, msg=devname)
             elif dev == 3:
-                # for can d every fourth mailbox should have a message
-                self.assertequal(iflag1_val, 0x11111111, msg=devname)
-                self.assertequal(iflag2_val, 0x11111111, msg=devname)
+                # For CAN D every fourth mailbox should have a message
+                self.assertEqual(iflag1_val, 0x11111111, msg=devname)
+                self.assertEqual(iflag2_val, 0x11111111, msg=devname)
 
-            # now ensure that all mailboxes that were not in the list are still
+            # Now ensure that all mailboxes that were not in the list are still
             # inactive and empty
-            for mb in range(flexcan_num_mbs):
+            for mb in range(FLEXCAN_NUM_MBs):
                 if mb not in rx_mbs:
-                    addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
+                    addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
 
-                    # ensure that nothing has been received in this mailbox
-                    self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), inactive_mb, msg=testmsg)
+                    # Ensure that nothing has been received in this mailbox
+                    self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), inactive_mb, msg=testmsg)
 
-            # generate one more message and send it, this should cause the code
-            # of the last mailbox configured for receive to be set to overrun
+            # Generate one more message and send it, this should cause the CODE
+            # of the last mailbox configured for receive to be set to OVERRUN
             # but should not generate any new interrupts
             overflow_msg = generate_msg(rtr=0)
 
-            # ensure that this doesn't match the last sent message (which should
+            # Ensure that this doesn't match the last sent message (which should
             # be in the last mailbox)
             #
-            self.assertnotequal(overflow_msg, msgs[-1], devname)
-            self.emu.can[dev].processreceiveddata(overflow_msg)
+            self.assertNotEqual(overflow_msg, msgs[-1], devname)
+            self.emu.can[dev].processReceivedData(overflow_msg)
 
-            # ensure that the message in the last receive mailbox still matches
+            # Ensure that the message in the last receive mailbox still matches
             # the last message received
             testmsg = '%s[%d]' % (devname, last_mb)
-            overflow_msg_data = msgs[-1].encode(code=flexcan.flexcan_code_rx_overrun, timestamp=last_timestamp)
-            addr = baseaddr + flexcan_mb_offset + (last_mb * flexcan_mbx_size)
-            self.assertequal(self.emu.readmemory(addr, flexcan_mbx_size), overflow_msg_data, msg=testmsg)
+            overflow_msg_data = msgs[-1].encode(code=flexcan.FLEXCAN_CODE_RX_OVERRUN, timestamp=last_timestamp)
+            addr = baseaddr + FLEXCAN_MB_OFFSET + (last_mb * FLEXCAN_MBx_SIZE)
+            self.assertEqual(self.emu.readMemory(addr, FLEXCAN_MBx_SIZE), overflow_msg_data, msg=testmsg)
 
-            # and ensure that there are no new interrupts
-            self.assertequal(self._getpendingexceptions(), [], msg=testmsg)
+            # And ensure that there are no new interrupts
+            self.assertEqual(self._getPendingExceptions(), [], msg=testmsg)
 
     def test_flexcan_rx_fifo(self):
-        # because this test attempts to test the accuracy of emulated timers
+        # Because this test attempts to test the accuracy of emulated timers
         # force the system time scaling factor to be 0.01 (100 real milliseconds
         # to 1 emulated millisecond).
         self.emu._systime_scaling = 0.1
 
-        # set standard bus speeds
+        # Set standard bus speeds
         self.set_baudrates()
 
-        # only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
+        # Only enable some of the mailbox interrupts: 0-7, 24-31, 32-47
         enabled_intrs = list(range(0, 8)) + list(range(24, 32)) + list(range(32, 48))
 
         for dev in range(4):
-            devname, baseaddr = flexcan_devices[dev]
-            mcr_addr = baseaddr + flexcan_mcr_offset
+            devname, baseaddr = FLEXCAN_DEVICES[dev]
+            mcr_addr = baseaddr + FLEXCAN_MCR_OFFSET
 
-            # configure the following things:
-            # - enable all interrupts
-            self.emu.writememvalue(baseaddr + flexcan_imask1_offset, 0xffffffff, 4)
-            self.emu.writememvalue(baseaddr + flexcan_imask2_offset, 0xffffffff, 4)
+            # Configure the following things:
+            # - Enable all interrupts
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK1_OFFSET, 0xFFFFFFFF, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IMASK2_OFFSET, 0xFFFFFFFF, 4)
 
-            # - clear all filter masks
-            self.emu.writememvalue(baseaddr + flexcan_rxgmask_offset, 0, 4)
-            self.emu.writememvalue(baseaddr + flexcan_rx14mask_offset, 0, 4)
-            self.emu.writememvalue(baseaddr + flexcan_rx15mask_offset, 0, 4)
+            # - Clear all filter masks
+            self.emu.writeMemValue(baseaddr + FLEXCAN_RXGMASK_OFFSET, 0, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_RX14MASK_OFFSET, 0, 4)
+            self.emu.writeMemValue(baseaddr + FLEXCAN_RX15MASK_OFFSET, 0, 4)
 
-            # - set all non-rxfifo mailboxes to inactive
-            for mb in range(6, flexcan_num_mbs):
-                addr = baseaddr + flexcan_mb_offset + (mb * flexcan_mbx_size)
-                self.emu.writememvalue(addr, flexcan.flexcan_code_rx_inactive, 1)
+            # - Set all non-RxFIFO mailboxes to INACTIVE
+            for mb in range(6, FLEXCAN_NUM_MBs):
+                addr = baseaddr + FLEXCAN_MB_OFFSET + (mb * FLEXCAN_MBx_SIZE)
+                self.emu.writeMemValue(addr, flexcan.FLEXCAN_CODE_RX_INACTIVE, 1)
 
-            # - change mode to normal and enable rx fifo
-            self.emu.writememvalue(mcr_addr, flexcan_mcr_fen_mask, 4)
-            self.assertequal(self.emu.can[dev].mode, flexcan.flexcan_mode.normal, devname)
-            self.assertequal(self.emu.can[dev].registers.mcr.fen, 1, devname)
+            # - Change mode to NORMAL and enable Rx FIFO
+            self.emu.writeMemValue(mcr_addr, FLEXCAN_MCR_FEN_MASK, 4)
+            self.assertEqual(self.emu.can[dev].mode, flexcan.FLEXCAN_MODE.NORMAL, devname)
+            self.assertEqual(self.emu.can[dev].registers.mcr.fen, 1, devname)
             start_time = time.time()
 
-            # generate 6 messages to send
+            # Generate 6 messages to send
             msgs = [generate_msg() for i in range(6)]
 
-            # it is expected that the calculated timestamp will be slightly
+            # It is expected that the calculated timestamp will be slightly
             # larger than the actual timestamp because it is saved right
             # after the memory write occurs that causes the transmit
             margin = self.emu.can[dev].speed * 0.0050 * self.emu._systime_scaling
@@ -1245,120 +1245,120 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
             # temporarily disable the garbage collector
             gc.disable()
 
-            # the rxfifo can hold 6 messages, each received message should
-            # generate a rxfifo msg available interrupt (mb5), when the last
-            # message is queued an rxfifo warning interrupt (mb6) should be
+            # The RxFIFO can hold 6 messages, each received message should
+            # generate a RxFIFO Msg Available interrupt (MB5), when the last
+            # message is queued an RxFIFO Warning interrupt (MB6) should be
             # generated
             rx_times = []
             for i in range(len(msgs)):
-                testmsg = '%s rxfifo[%d]' % (devname, i)
-                self.emu.can[dev].processreceiveddata(msgs[i])
+                testmsg = '%s RxFIFO[%d]' % (devname, i)
+                self.emu.can[dev].processReceivedData(msgs[i])
                 rx_times.append(time.time())
                 time.sleep(0.1)
 
-                # there should be one rxfifo msg available interrupt (mb5) when
-                # the first message is sent, then an rxfifo warning interrupt
-                # (mb6) after the 6th message is sent.
+                # There should be one RxFIFO Msg Available interrupt (MB5) when
+                # the first message is sent, then an RxFIFO Warning interrupt
+                # (MB6) after the 6th message is sent.
                 if i == 0:
-                    self.assertequal(self._getpendingexceptions(), [get_int(dev, 5)], msg=testmsg)
+                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, 5)], msg=testmsg)
                 elif i == 5:
-                    self.assertequal(self._getpendingexceptions(), [get_int(dev, 6)], msg=testmsg)
+                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, 6)], msg=testmsg)
 
-            # only mb5 and mb6 interrupt flags should be set
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            iflag2_val = self.emu.readmemvalue(baseaddr + flexcan_iflag2_offset, 4)
-            self.assertequal(iflag1_val, 0x00000060, msg=devname)
-            self.assertequal(iflag2_val, 0x00000000, msg=devname)
+            # Only MB5 and MB6 interrupt flags should be set
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            iflag2_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG2_OFFSET, 4)
+            self.assertEqual(iflag1_val, 0x00000060, msg=devname)
+            self.assertEqual(iflag2_val, 0x00000000, msg=devname)
 
-            # send one more message and ensure the rxfifo overflow interrupt
-            # (mb7) happens
+            # Send one more message and ensure the RxFIFO Overflow interrupt
+            # (MB7) happens
             lost_msg = generate_msg()
-            self.emu.can[dev].processreceiveddata(lost_msg)
+            self.emu.can[dev].processReceivedData(lost_msg)
 
-            self.assertequal(self._getpendingexceptions(), [get_int(dev, 7)], msg=testmsg)
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            self.assertequal(iflag1_val, 0x000000e0, msg=devname)
+            self.assertEqual(self._getPendingExceptions(), [get_int(dev, 7)], msg=testmsg)
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            self.assertEqual(iflag1_val, 0x000000E0, msg=devname)
 
-            # now read a message from the rxfifo (mb0).
-            # randomize how this data is read from the mailbox registers, it
+            # Now read a message from the RxFIFO (MB0).
+            # Randomize how this data is read from the mailbox registers, it
             # can be read in 1, 2 or 4 byte chunks.
             first_msg = read_mb_data(self.emu, dev, 0)
             rx_msgs = [first_msg]
 
-            # reading the fifo without clearing the interrupt flag should not
+            # Reading the FIFO without clearing the interrupt flag should not
             # change the available data, read again and confirm the data matches
-            self.assertequal(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
+            self.assertEqual(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
 
-            # clear the overflow and warning interrupt flags and ensure that the
-            # message in mb0 doesn't change
-            self.emu.writememvalue(baseaddr + flexcan_iflag1_offset, 0x000000c0, 4)
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            self.assertequal(iflag1_val, 0x00000020, msg=devname)
-            self.assertequal(self._getpendingexceptions(), [], msg=devname)
+            # Clear the overflow and warning interrupt flags and ensure that the
+            # message in MB0 doesn't change
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 0x000000C0, 4)
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            self.assertEqual(iflag1_val, 0x00000020, msg=devname)
+            self.assertEqual(self._getPendingExceptions(), [], msg=devname)
 
-            self.assertequal(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
+            self.assertEqual(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
 
-            # clear the mb5 interrupt flag and ensure that a new rxfifo msg
-            # available interrupt (mb5) happens and that a new message is
-            # available in mb0
-            self.emu.writememvalue(baseaddr + flexcan_iflag1_offset, 0x00000020, 4)
-            self.assertequal(self._getpendingexceptions(), [get_int(dev, 5)], msg=devname)
+            # Clear the MB5 interrupt flag and ensure that a new RxFIFO Msg
+            # Available interrupt (MB5) happens and that a new message is
+            # available in MB0
+            self.emu.writeMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 0x00000020, 4)
+            self.assertEqual(self._getPendingExceptions(), [get_int(dev, 5)], msg=devname)
 
-            self.assertnotequal(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
+            self.assertNotEqual(read_mb_data(self.emu, dev, 0), first_msg, msg=devname)
 
-            # the mb5 interrupt flag should be set again
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            self.assertequal(iflag1_val, 0x00000020, msg=devname)
+            # the MB5 interrupt flag should be set again
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            self.assertEqual(iflag1_val, 0x00000020, msg=devname)
 
-            # send another message and ensure the rxfifo warning is set again
+            # Send another message and ensure the RxFIFO Warning is set again
             msgs.append(generate_msg())
-            self.emu.can[dev].processreceiveddata(msgs[-1])
+            self.emu.can[dev].processReceivedData(msgs[-1])
             rx_times.append(time.time())
 
-            self.assertequal(self._getpendingexceptions(), [get_int(dev, 6)], msg=testmsg)
-            iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
-            self.assertequal(iflag1_val, 0x00000060, msg=devname)
+            self.assertEqual(self._getPendingExceptions(), [get_int(dev, 6)], msg=testmsg)
+            iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
+            self.assertEqual(iflag1_val, 0x00000060, msg=devname)
 
-            # read the remaining 5 messages from the rxfifo
+            # Read the remaining 5 messages from the RxFIFO
             while iflag1_val:
-                # save the message in mb0
+                # Save the message in MB0
                 msg = read_mb_data(self.emu, dev, 0)
                 rx_msgs.append(msg)
 
-                # clear the interrupt flags, this should trigger a new interrupt
-                # if we have not read all of the messages from the fifo
-                self.emu.writememvalue(baseaddr + flexcan_iflag1_offset, iflag1_val, 4)
-                iflag1_val = self.emu.readmemvalue(baseaddr + flexcan_iflag1_offset, 4)
+                # Clear the interrupt flags, this should trigger a new interrupt
+                # if we have not read all of the messages from the FIFO
+                self.emu.writeMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, iflag1_val, 4)
+                iflag1_val = self.emu.readMemValue(baseaddr + FLEXCAN_IFLAG1_OFFSET, 4)
 
                 if len(rx_msgs) != len(msgs):
-                    self.assertequal(iflag1_val, 0x00000020, msg=devname)
-                    self.assertequal(self._getpendingexceptions(), [get_int(dev, 5)], msg=devname)
+                    self.assertEqual(iflag1_val, 0x00000020, msg=devname)
+                    self.assertEqual(self._getPendingExceptions(), [get_int(dev, 5)], msg=devname)
                 else:
-                    self.assertequal(iflag1_val, 0x00000000, msg=devname)
+                    self.assertEqual(iflag1_val, 0x00000000, msg=devname)
 
-            # sanity check, the number of received messages should now match the
+            # Sanity check, the number of received messages should now match the
             # number of sent messages and the number of receive times recorded.
-            self.assertequal(len(rx_msgs), len(msgs), msg=devname)
-            self.assertequal(len(rx_msgs), len(rx_times), msg=devname)
+            self.assertEqual(len(rx_msgs), len(msgs), msg=devname)
+            self.assertEqual(len(rx_msgs), len(rx_times), msg=devname)
 
             # it can be re-enabled now
             gc.enable()
 
-            # go through the received messages and timestamps and ensure that
+            # Go through the received messages and timestamps and ensure that
             # messages were received correctly.
             for i in range(len(msgs)):
-                testmsg = '%s rxfifo[%d]' % (devname, i)
+                testmsg = '%s RxFIFO[%d]' % (devname, i)
                 rx_delay = rx_times[i] - start_time
-                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xffff
+                expected_ticks = int(self.emu.can[dev].speed * rx_delay * self.emu._systime_scaling) & 0xFFFF
 
-                timestamp = struct.unpack_from('>h', rx_msgs[i], 2)[0]
-                self.assertalmostequal(timestamp, expected_ticks, delta=margin, msg=testmsg)
+                timestamp = struct.unpack_from('>H', rx_msgs[i], 2)[0]
+                self.assertAlmostEqual(timestamp, expected_ticks, delta=margin, msg=testmsg)
 
-                # now that the timestamp has been confirmed to be within the
+                # Now that the timestamp has been confirmed to be within the
                 # expected range, ensure that the received message in the
                 # matches what was sent
                 msg_data = msgs[i].encode(code=0, timestamp=timestamp)
-                self.assertequal(rx_msgs[i], msg_data, msg=testmsg)
+                self.assertEqual(rx_msgs[i], msg_data, msg=testmsg)
 
     @unittest.skip('todo')
     def test_flexcan_rx_filters(self):
@@ -1378,7 +1378,8 @@ class MPC5674_FlexCAN_Test(MPC5674_Test):
 
 
 class MPC5674_FlexCAN_RealIO(MPC5674_Test):
-    args = MPC5674_Test.args + [
+    args = [
+        '-c',
         '-O', 'project.MPC5674.FlexCAN_A.port=10001',
         '-O', 'project.MPC5674.FlexCAN_B.port=10002',
         '-O', 'project.MPC5674.FlexCAN_C.port=10003',

--- a/cm2350/tests/test_mpc5674_fmpll.py
+++ b/cm2350/tests/test_mpc5674_fmpll.py
@@ -84,8 +84,8 @@ class MPC5674_FMPLL_Test(MPC5674_Test):
 
     # Add specific EXTAL and PLLCFG startup arguments
     args = MPC5674_Test.args + [
-        '-O', 'project.MPC5674.FMPLL.extal=%d' % self.EXTAL,
-        '-O', 'project.MPC5674.SIU.pllcfg=%d' % self.PLLCFG,
+        '-O', 'project.MPC5674.FMPLL.extal=%d' % EXTAL,
+        '-O', 'project.MPC5674.SIU.pllcfg=%d' % PLLCFG,
     ]
 
     def test_fmpll_synsr_defaults(self):
@@ -397,6 +397,12 @@ class MPC5674_FMPLL_20MHz_Test(MPC5674_FMPLL_Test):
         13333333.33333333,  # ESYNCR2[ERFD] = 5
     ]
 
+    # Add specific EXTAL and PLLCFG startup arguments
+    args = MPC5674_Test.args + [
+        '-O', 'project.MPC5674.FMPLL.extal=%d' % EXTAL,
+        '-O', 'project.MPC5674.SIU.pllcfg=%d' % PLLCFG,
+    ]
+
 
 class MPC5674_FMPLL_10MHz_Test(MPC5674_FMPLL_Test):
     # 10MHz external clock
@@ -441,4 +447,10 @@ class MPC5674_FMPLL_10MHz_Test(MPC5674_FMPLL_Test):
         7500000.0,          # ESYNCR1[EPREDIV] = 7
         5000000.0,          # ESYNCR1[EMFD] = 16
         6666666.66666666,   # ESYNCR2[ERFD] = 5
+    ]
+
+    # Add specific EXTAL and PLLCFG startup arguments
+    args = MPC5674_Test.args + [
+        '-O', 'project.MPC5674.FMPLL.extal=%d' % EXTAL,
+        '-O', 'project.MPC5674.SIU.pllcfg=%d' % PLLCFG,
     ]

--- a/cm2350/tests/test_mpc5674_fmpll.py
+++ b/cm2350/tests/test_mpc5674_fmpll.py
@@ -82,14 +82,11 @@ class MPC5674_FMPLL_Test(MPC5674_Test):
         26666666.66666666,  # ESYNCR2[ERFD] = 5
     ]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Add specific EXTAL and PLLCFG startup arguments
-        self.args = MPC5674_Test.args + [
-            '-O', 'project.MPC5674.FMPLL.extal=%d' % self.EXTAL,
-            '-O', 'project.MPC5674.SIU.pllcfg=%d' % self.PLLCFG,
-        ]
+    # Add specific EXTAL and PLLCFG startup arguments
+    args = MPC5674_Test.args + [
+        '-O', 'project.MPC5674.FMPLL.extal=%d' % self.EXTAL,
+        '-O', 'project.MPC5674.SIU.pllcfg=%d' % self.PLLCFG,
+    ]
 
     def test_fmpll_synsr_defaults(self):
         self.assertEqual(self.emu.readMemory(FMPLL_SYNSR, 4), FMPLL_SYNSR_DEFAULT_BYTES)

--- a/cm2350/tests/test_mpc5674_swt.py
+++ b/cm2350/tests/test_mpc5674_swt.py
@@ -1,4 +1,3 @@
-import time
 import random
 
 import envi.bits as e_bits
@@ -33,6 +32,15 @@ SWT_MCR_ENABLE_WDOG   = 0xff00010b
 SWT_TO_DEFAULT        = 0x0005fcd0
 SWT_MCR_DEFAULT_BYTES = b'\xff\x00\x01\x0a'
 SWT_TO_DEFAULT_BYTES  = b'\x00\x05\xfc\xd0'
+
+# SIU and ECSM constants for checking reset sources
+SIU_RSR         = (0xC3F9000C, 4)
+SIU_RSR_PORS    = 0x80008000
+SIU_RSR_SWTRS   = 0x02008000
+
+ECSM_MRSR       = (0xFFF4000F, 1)
+ECSM_MRSR_POR   = 0x80
+ECSM_MRSR_SWTR  = 0x20
 
 
 class MPC5674_WDT_Test(MPC5674_Test):
@@ -159,7 +167,7 @@ class MPC5674_WDT_Test(MPC5674_Test):
 
         # The SWT is enabled and running by default, ensure that the timeout
         # period matches the default TO value
-        self.assertEqual(self.emu.swt.watchdog.period, SWT_TO_DEFAULT)
+        self.assertEqual(self.emu.swt.watchdog._ticks, SWT_TO_DEFAULT)
 
     def test_swt_wn_defaults(self):
         self.assertEqual(self.emu.readMemory(SWT_WN, 4), b'\x00\x00\x00\x00')
@@ -190,6 +198,13 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.swt._sk_idx, 0)
 
     def test_swt_co_defaults(self):
+        # Watchdog should be disabled by default because the SWT flag in the BAM 
+        # RCHW entry isn't set.
+        self.assertEqual(self.emu.swt.watchdog.running(), False)
+
+        # Pause the emulator system time so no emulated time elapses
+        self.emu.halt_time()
+
         # Enable the watchdog
         self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
         self.assertEqual(self.emu.swt.watchdog.running(), True)
@@ -199,9 +214,6 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # have the same value as the TO initialization value
         self.assertEqual(self.emu.readMemory(SWT_CO, 4), SWT_TO_DEFAULT_BYTES)
         self.assertEqual(self.emu.readMemValue(SWT_CO, 4), SWT_TO_DEFAULT)
-
-        # There is no "co" attribute in the SWT class so it can't be
-        # read directly.
 
         # Stop the watchdog timer
         clear_wen_val = SWT_MCR_ENABLE_WDOG & 0xFFFFFFFE
@@ -250,12 +262,14 @@ class MPC5674_WDT_Test(MPC5674_Test):
             msg = 'invalid read from 0x%x' % test_addr
             with self.assertRaises(intc_exc.ResetException, msg=msg) as cm:
                 self.emu.readMemory(test_addr, 4)
+            self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
             self.assertEqual(cm.exception.kwargs, {}, msg=msg)
 
             # Write the test value to the test address
             msg = 'invalid write of 0x%x to 0x%x' % (test_val, test_addr)
             with self.assertRaises(intc_exc.ResetException, msg=msg) as cm:
                 self.emu.writeMemValue(test_addr, test_val, 4)
+            self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
             self.assertEqual(cm.exception.kwargs, {}, msg=msg)
 
     def test_swt_invalid_access_error_ria_clear_wen_set(self):
@@ -288,6 +302,10 @@ class MPC5674_WDT_Test(MPC5674_Test):
             self.validate_invalid_addr(test_addr, 4)
 
     def test_swt_ro_reg_writes_sysreset(self):
+
+        mrsr_addr, mrsr_size = ECSM_MRSR
+        rsr_addr, rsr_size = SIU_RSR
+
         # Writes to read-only registers should generate Bus Errors or resets
         # depending on RIA
         unlocked_ro_regs = [SWT_CO]
@@ -321,12 +339,22 @@ class MPC5674_WDT_Test(MPC5674_Test):
             self.emu.setProgramCounter(test_pc)
 
             # Should be no pending exceptions by default
-            self.assertEqual(self._getPendingExceptions(), [])
+            self.assertEqual(self.checkPendingExceptions(), [])
 
             msg = 'invalid write of 0x%x to 0x%x' % (test_val, test_addr)
             with self.assertRaises(intc_exc.ResetException, msg=msg) as cm:
                 self.emu.writeMemValue(test_addr, test_val, 4)
+            self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
             self.assertEqual(cm.exception.kwargs, {}, msg=msg)
+
+            self.emu.queueException(cm.exception)
+            self.emu.stepi()
+
+            # queue the exception as it would be if this had happened while 
+            # processing an instruction, step and then check that the watchdog 
+            # is marked as the source of the reset
+            self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+            self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)
 
         # Lock the SWT and try again
         lock_swt_val = SWT_MCR_ENABLE_WDOG | 0x00000010
@@ -345,12 +373,22 @@ class MPC5674_WDT_Test(MPC5674_Test):
             self.emu.setProgramCounter(test_pc)
 
             # Should be no pending exceptions by default
-            self.assertEqual(self._getPendingExceptions(), [])
+            self.assertEqual(self.checkPendingExceptions(), [])
 
             msg = 'invalid write of 0x%x to 0x%x' % (test_val, test_addr)
             with self.assertRaises(intc_exc.ResetException, msg=msg) as cm:
                 self.emu.writeMemValue(test_addr, test_val, 4)
+            self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
             self.assertEqual(cm.exception.kwargs, {}, msg=msg)
+
+            self.emu.queueException(cm.exception)
+            self.emu.stepi()
+
+            # queue the exception as it would be if this had happened while 
+            # processing an instruction, step and then check that the watchdog 
+            # is marked as the source of the reset
+            self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+            self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)
 
     def test_swt_ro_reg_writes_buserror(self):
         # Writes to read-only registers should generate Bus Errors or resets
@@ -405,13 +443,13 @@ class MPC5674_WDT_Test(MPC5674_Test):
 
         # Before a reset the ECSM MRSR[SWTR] should be 0 and MRSR[POR] should be
         # set since this was the first boot.
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 1)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_PORS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_POR)
 
         # Attempt to unlock by writing to MCR and ensure this fails
         with self.assertRaises(intc_exc.ResetException) as cm:
             self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
+        self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
         self.assertEqual(cm.exception.kwargs, {})
 
         # MCR values should be unchanged
@@ -420,12 +458,15 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.swt.registers.mcr.slk, 1)
         self.assertEqual(self.emu.swt.locked(), True)
 
-        # After a non-watchdog reset the ECSM MRSR[SWTR] and MRSR[POR] should be
-        # 0 and MRSR[DIR] should be 1
-        self.emu.reset()
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 1)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
+        # Cause a reset with the captured exception
+        self.emu.queueException(cm.exception)
+        self.emu.stepi()
+
+        # queue the exception as it would be if this had happened while 
+        # processing an instruction, step and then check that the watchdog is 
+        # marked as the source of the reset
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)
 
         # Since we reset, set the SLK flag again
         lock_swt_val = SWT_MCR_ENABLE_WDOG | 0x00000010
@@ -475,6 +516,7 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # Attempt to unlock by writing to MCR and ensure this fails
         with self.assertRaises(intc_exc.ResetException) as cm:
             self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
+        self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
         self.assertEqual(cm.exception.kwargs, {})
 
         # MCR values should be unchanged
@@ -483,12 +525,17 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.swt.registers.mcr.slk, 1)
         self.assertEqual(self.emu.swt.locked(), True)
 
-        # After a non-watchdog reset the ECSM MRSR[SWTR] and MRSR[POR] should be
-        # 0 and MRSR[DIR] should be 1
-        self.emu.reset()
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 1)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
+        # Cause a reset with the captured exception
+        self.emu.queueException(cm.exception)
+        self.emu.stepi()
+
+        # Pause the emulated system time and reset it back to 0
+        self.emu.halt_time()
+        self.emu.systime(-self.emu.systime())
+
+        # check that the watchdog is marked as the source of the reset
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)
 
         # Since we reset, set the SLK flag again
         lock_swt_val = SWT_MCR_ENABLE_WDOG | 0x00000010
@@ -523,8 +570,8 @@ class MPC5674_WDT_Test(MPC5674_Test):
 
         # The watchdog hasn't run yet so there should be the full period left
         wdt_time = SWT_TO_DEFAULT / self.emu.swt.watchdog.freq
-        self.assertEqual(self.emu.swt.watchdog.ticks(), SWT_TO_DEFAULT)
         self.assertEqual(self.emu.swt.watchdog.time(), wdt_time)
+        self.assertEqual(self.emu.swt.watchdog.ticks(), SWT_TO_DEFAULT)
 
         # Force the system time forward 0.005 emulated seconds so we can tell 
         # when the watchdog is restarted (do this by moving starting sysoffset 
@@ -603,14 +650,14 @@ class MPC5674_WDT_Test(MPC5674_Test):
 
         # Before a reset the ECSM MRSR[SWTR] should be 0 and MRSR[POR] should be
         # set since this was the first boot.
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 1)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_PORS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_POR)
 
         # Attempt to unlock by writing to MCR and ensure this fails
         # This should generate a ResetException
         with self.assertRaises(intc_exc.ResetException) as cm:
             self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
+        self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
         self.assertEqual(cm.exception.kwargs, {})
 
         # Write the soft unlock sequence and ensure that the HLK flag is
@@ -623,7 +670,8 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.swt.registers.mcr.slk, 0)
         self.assertEqual(self.emu.swt.locked(), True)
 
-        # Watchdog should still be running
+        # We haven't processed the reset exception yet so the watchdog should 
+        # still be running
         self.assertEqual(self.emu.swt.registers.mcr.wen, 1)
         self.assertEqual(self.emu.swt.watchdog.running(), True)
 
@@ -631,16 +679,24 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # This should generate a ResetException
         with self.assertRaises(intc_exc.ResetException) as cm:
             self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
+        self.assertEqual(cm.exception.source, intc_exc.ResetSource.WATCHDOG)
         self.assertEqual(cm.exception.kwargs, {})
 
-        # The reset reason was not a SWT reset so the ECSM MRSR[SWTR] should be
-        # 0, MRSR[POR] is 0, and the MRSR[DIR] is 1
-        self.emu.reset()
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 1)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
+        # Cause a reset with the captured exception
+        self.emu.queueException(cm.exception)
+        self.emu.stepi()
+
+        # queue the exception as it would be if this had happened while 
+        # processing an instruction, step and then check that the watchdog is 
+        # marked as the source of the reset
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)
 
     def test_swt_xtal_freq(self):
+        # Pause the emulated system time and reset it back to 0
+        self.emu.halt_time()
+        self.emu.systime(-self.emu.systime())
+
         default_extal = self.emu.vw.config.project.MPC5674.FMPLL.extal
 
         # Enable the watchdog
@@ -683,11 +739,6 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # Enable the watchdog
         self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
 
-        # Because this test attempts to test the accuracy of emulated timeouts
-        # force the system time scaling factor to be 0.01 (100 real milliseconds
-        # to 1 emulated millisecond).
-        self.emu._systime_scaling = 0.01
-
         # Default value of MCR[ITR] (TIF) is 0 so the first watchdog expiration
         # will
         # generate a ResetException
@@ -698,26 +749,29 @@ class MPC5674_WDT_Test(MPC5674_Test):
         default_extal = self.emu.vw.config.project.MPC5674.FMPLL.extal
         wdt_time = SWT_TO_DEFAULT / default_extal
 
-        self.assertEqual(self.emu.systime(), 0.0)
+        start = self.emu.systime()
 
         # The default timeout time is 0.00981 seconds, divide the timeout time
         # by 0.01 to get the real amount of time to sleep for half of the
         # watchdog time to elapse for the emulator.
-        sleep_time = (wdt_time * 0.5) / self.emu._systime_scaling
+        sleep_time = wdt_time * 0.5
         self.emu.resume_time()
-        time.sleep(sleep_time)
+        self.emu.sleep(sleep_time)
         self.emu.halt_time()
+
+        # Get current system time
+        now = self.emu.systime()
 
         # It's unlikely the python timing will be accurate enough so that the
         # system time is now the sleep_time. but it should be less than the
         # watchdog time
-        self.assertGreater(self.emu.systime(), wdt_time * 0.5)
-        self.assertLess(self.emu.systime(), wdt_time)
+        self.assertGreater(now - start, wdt_time * 0.5)
+        self.assertLess(now - start, wdt_time)
 
         # The watchdog should not have expired yet
         self.assertEqual(self.emu.swt.watchdog.running(), True)
 
-        self.assertEqual(self._getPendingExceptions(), [])
+        self.assertEqual(self.checkPendingExceptions(), [])
 
         # Before the SWT watchdog generates a reset the ECSM MRSR[SWTR] should
         # be 0 and MRSR[POR] should be set since this was the first boot.
@@ -726,32 +780,33 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
 
         # Run for a full WDT time
-        sleep_time = wdt_time / self.emu._systime_scaling
+        sleep_time = wdt_time
         self.emu.resume_time()
-        time.sleep(sleep_time)
+        self.emu.sleep(sleep_time)
         self.emu.halt_time()
 
+        # Get current system time
+        now = self.emu.systime()
+
         # The watchdog timer should have expired by now
-        self.assertGreater(self.emu.systime(), wdt_time)
+        self.assertGreater(now - start, wdt_time)
 
         self.assertEqual(self.emu.swt.watchdog.running(), False)
-        reset_exc = intc_exc.ResetException()
-        self.assertEqual(self._getPendingExceptions(), [reset_exc])
+        reset_exc = intc_exc.ResetException(intc_exc.ResetSource.WATCHDOG)
+        self.assertEqual(self.checkPendingExceptions(), [reset_exc])
 
-        # Ensure that the ECSM MRSR[SWTR] flag is set and MRSR[POR] is 0
-        self.emu.reset()
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 1)
+        # Process the reset exception
+        self.emu.stepi()
+
+        # queue the exception as it would be if this had happened while 
+        # processing an instruction, step and then check that the watchdog is 
+        # marked as the source of the reset
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)
 
     def test_swt_expire_interrupt(self):
         # Enable the watchdog
         self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
-
-        # Because this test attempts to test the accuracy of emulated timeouts
-        # force the system time scaling factor to be 0.01 (100 real milliseconds
-        # to 1 emulated millisecond).
-        self.emu._systime_scaling = 0.01
 
         # Change MCR[ITR] so that the first watchdog expiration generates an
         # interrupt, and the second one generates a reset
@@ -766,20 +821,16 @@ class MPC5674_WDT_Test(MPC5674_Test):
         default_extal = self.emu.vw.config.project.MPC5674.FMPLL.extal
         wdt_time = SWT_TO_DEFAULT / default_extal
 
-        now = self.emu.systime()
-        logger.debug('0. [%f] (WDT timeout = %f)', now, wdt_time)
+        # Get the start emulated time
+        start = self.emu.systime()
 
-        self.assertEqual(self.emu.systime(), 0.0)
+        logger.debug('0. [%f] (WDT timeout = %f)', start, wdt_time)
 
         # resume the system time, wait half of the WDT time and then halt the
         # system again to stop time from counting
-
-        # The default timeout time is 0.00981 seconds, divide the timeout time
-        # by 0.01 to get the real amount of time to sleep for half of the
-        # watchdog time to elapse for the emulator.
-        sleep_time = (wdt_time * 0.5) / self.emu._systime_scaling
+        sleep_time = wdt_time * 0.5
         self.emu.resume_time()
-        time.sleep(sleep_time)
+        self.emu.sleep(sleep_time)
         self.emu.halt_time()
 
         # It's unlikely the python timing will be accurate enough so that the
@@ -787,53 +838,57 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # watchdog time
         now = self.emu.systime()
         logger.debug('1. [%f] WDT time remaining = %f', now, self.emu.swt.watchdog.time())
-        self.assertGreater(now, wdt_time * 0.5)
-        self.assertLess(now, wdt_time)
+        self.assertGreater(now - start, wdt_time * 0.5)
+        self.assertLess(now - start, wdt_time)
 
         # The watchdog should not have expired yet
         self.assertEqual(self.emu.swt.watchdog.running(), True)
-        self.assertEqual(self._getPendingExceptions(), [])
+        self.assertEqual(self.checkPendingExceptions(), [])
 
         # Run for a full WDT time
-        sleep_time = wdt_time / self.emu._systime_scaling
+        sleep_time = wdt_time
         self.emu.resume_time()
-        time.sleep(sleep_time)
+        self.emu.sleep(sleep_time)
         self.emu.halt_time()
 
         # The watchdog timer should have expired by now, but only once
         now = self.emu.systime()
         logger.debug('2. [%f] WDT time remaining = %f', now, self.emu.swt.watchdog.time())
-        self.assertGreater(now, wdt_time * 1.5)
-        self.assertLess(now, wdt_time * 2)
+        self.assertGreater(now - start, wdt_time * 1.5)
+        self.assertLess(now - start, wdt_time * 2)
 
         self.assertEqual(self.emu.swt.watchdog.running(), True)
         self.assertEqual(self._getPendingExceptions(),
                 [intc_exc.ExternalException(intc_exc.INTC_SRC.SWT)])
 
-        # Before the SWT watchdog generates a reset the ECSM MRSR[SWTR] should
-        # be 0 and MRSR[POR] should be set since this was the first boot.
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 1)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
+        # Before a reset the ECSM MRSR[SWTR] should be 0 and MRSR[POR] should be
+        # set since this was the first boot.
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_PORS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_POR)
 
         # Wait for another half WDT time for the watchdog to expire again.  The
         # second expiration should generate a ResetException
-        sleep_time = (wdt_time * 0.5) / self.emu._systime_scaling
+        sleep_time = wdt_time * 0.5
         self.emu.resume_time()
-        time.sleep(sleep_time)
+        self.emu.sleep(sleep_time)
         self.emu.halt_time()
 
         # Watchdog should have expired twice now
         now = self.emu.systime()
         logger.debug('3. [%f] WDT time remaining = %f', now, self.emu.swt.watchdog.time())
-        self.assertGreater(now, wdt_time * 2.0)
-        self.assertLess(now, wdt_time * 2.5)
+        self.assertGreater(now - start, wdt_time * 2.0)
+        self.assertLess(now - start, wdt_time * 2.5)
         self.assertEqual(self.emu.swt.watchdog.running(), False)
-        reset_exc = intc_exc.ResetException()
-        self.assertEqual(self._getPendingExceptions(), [reset_exc])
 
-        # Ensure that the ECSM MRSR[SWTR] flag is set and MRSR[POR] is 0
-        self.emu.reset()
-        self.assertEqual(self.emu.ecsm.registers.mrsr.por, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 0)
-        self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 1)
+        # a reset exception should be queued
+        reset_exc = intc_exc.ResetException(intc_exc.ResetSource.WATCHDOG)
+        self.assertEqual(self.checkPendingExceptions(), [reset_exc])
+
+        # Process the reset exception
+        self.emu.stepi()
+
+        # queue the exception as it would be if this had happened while 
+        # processing an instruction, step and then check that the watchdog is 
+        # marked as the source of the reset
+        self.assertEqual(self.emu.readMemValue(*SIU_RSR), SIU_RSR_SWTRS)
+        self.assertEqual(self.emu.readMemValue(*ECSM_MRSR), ECSM_MRSR_SWTR)

--- a/cm2350/tests/test_mpc5674_swt.py
+++ b/cm2350/tests/test_mpc5674_swt.py
@@ -588,9 +588,6 @@ class MPC5674_WDT_Test(MPC5674_Test):
 
         new_ticks = int(new_time * self.emu.swt.watchdog.freq)
 
-        # Because the new times are intentionally calculated differently than
-        # how the watchdog timeouts are calculated the new tick value may be off
-        # by as much as (0.000001 * frequency)
         tick_delta = 0.000001 * self.emu.swt.watchdog.freq
         self.assertAlmostEqual(self.emu.swt.watchdog.ticks(), new_ticks, delta=tick_delta)
 
@@ -604,8 +601,8 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # The watchdog should still be running but the duration should be back
         # to the full period
         self.assertEqual(self.emu.swt.watchdog.running(), True)
-        self.assertAlmostEqual(self.emu.swt.watchdog.time(), wdt_time)
         self.assertEqual(self.emu.swt.watchdog.ticks(), SWT_TO_DEFAULT)
+        self.assertAlmostEqual(self.emu.swt.watchdog.time(), wdt_time)
 
         # SWT is still locked
         self.assertEqual(self.emu.swt.registers.mcr.hlk, 0)
@@ -765,8 +762,8 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # It's unlikely the python timing will be accurate enough so that the
         # system time is now the sleep_time. but it should be less than the
         # watchdog time
-        self.assertGreater(now - start, wdt_time * 0.5)
-        self.assertLess(now - start, wdt_time)
+        self.assertGreaterEqual(now - start, wdt_time * 0.5)
+        self.assertLessEqual(now - start, wdt_time)
 
         # The watchdog should not have expired yet
         self.assertEqual(self.emu.swt.watchdog.running(), True)
@@ -838,7 +835,7 @@ class MPC5674_WDT_Test(MPC5674_Test):
         # watchdog time
         now = self.emu.systime()
         logger.debug('1. [%f] WDT time remaining = %f', now, self.emu.swt.watchdog.time())
-        self.assertGreater(now - start, wdt_time * 0.5)
+        self.assertGreaterEqual(now - start, wdt_time * 0.5)
         self.assertLess(now - start, wdt_time)
 
         # The watchdog should not have expired yet

--- a/cm2350/tests/test_mpc5674_swt.py
+++ b/cm2350/tests/test_mpc5674_swt.py
@@ -194,10 +194,6 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
         self.assertEqual(self.emu.swt.watchdog.running(), True)
 
-        # The system time is running when the system initializes, manually reset
-        # it which causes it to pause.
-        self.emu.systimeReset()
-
         # The SWT CO register should reflect the amount of time left before the
         # watchdog timer expires. Because the system starts paused it should
         # have the same value as the TO initialization value
@@ -527,14 +523,15 @@ class MPC5674_WDT_Test(MPC5674_Test):
 
         # The watchdog hasn't run yet so there should be the full period left
         wdt_time = SWT_TO_DEFAULT / self.emu.swt.watchdog.freq
-        self.assertEqual(self.emu.swt.watchdog.time(), wdt_time)
         self.assertEqual(self.emu.swt.watchdog.ticks(), SWT_TO_DEFAULT)
+        self.assertEqual(self.emu.swt.watchdog.time(), wdt_time)
 
-        # Force the system time forward 0.005 emulated seconds (0.005 /
-        # systime_scaling) so we can tell when the watchdog is restarted (do
-        # this by moving starting sysoffset back 0.005 seconds).  Any more than
-        # this and it will cause the watchdog to expire.
-        self.emu._sysoffset -= 0.005 / self.emu._systime_scaling
+        # Force the system time forward 0.005 emulated seconds so we can tell 
+        # when the watchdog is restarted (do this by moving starting sysoffset 
+        # back 0.005 seconds).  Any more than this and it will cause the 
+        # watchdog to expire.
+        updated_systime = self.emu.systime(0.005)
+        self.assertAlmostEqual(updated_systime, 0.005, places=6)
         new_time = wdt_time - 0.005
 
         # Because of the floating point numbers involved with the addition of

--- a/cm2350/tests/test_mpc5674_swt.py
+++ b/cm2350/tests/test_mpc5674_swt.py
@@ -194,6 +194,10 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.emu.writeMemValue(SWT_MCR, SWT_MCR_ENABLE_WDOG, 4)
         self.assertEqual(self.emu.swt.watchdog.running(), True)
 
+        # The system time is running when the system initializes, manually reset
+        # it which causes it to pause.
+        self.emu.systimeReset()
+
         # The SWT CO register should reflect the amount of time left before the
         # watchdog timer expires. Because the system starts paused it should
         # have the same value as the TO initialization value

--- a/cm2350/tests/test_mpc5674_swt.py
+++ b/cm2350/tests/test_mpc5674_swt.py
@@ -427,9 +427,6 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 1)
         self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
 
-        # restart the system timebase but keep it paused
-        self.emu.enableTimebase(start_paused=True)
-
         # Since we reset, set the SLK flag again
         lock_swt_val = SWT_MCR_ENABLE_WDOG | 0x00000010
         self.emu.writeMemValue(SWT_MCR, lock_swt_val, 4)
@@ -492,9 +489,6 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.ecsm.registers.mrsr.por, 0)
         self.assertEqual(self.emu.ecsm.registers.mrsr.dir, 1)
         self.assertEqual(self.emu.ecsm.registers.mrsr.swtr, 0)
-
-        # restart the system timebase but keep it paused
-        self.emu.enableTimebase(start_paused=True)
 
         # Since we reset, set the SLK flag again
         lock_swt_val = SWT_MCR_ENABLE_WDOG | 0x00000010

--- a/cm2350/tests/test_mpc5674_swt.py
+++ b/cm2350/tests/test_mpc5674_swt.py
@@ -730,8 +730,8 @@ class MPC5674_WDT_Test(MPC5674_Test):
         self.assertEqual(self.emu.swt.watchdog.running(), True)
 
         # The watchdog clock should now be using the platform/peripheral clock
-        self.assertEqual(self.emu.swt.watchdog.freq, self.emu.siu.f_periph())
-        wdt_time = SWT_TO_DEFAULT / self.emu.siu.f_periph()
+        self.assertEqual(self.emu.swt.watchdog.freq, self.emu.getClock('periph'))
+        wdt_time = SWT_TO_DEFAULT / self.emu.getClock('periph')
         self.assertEqual(self.emu.swt.watchdog.time(), wdt_time)
         self.assertEqual(self.emu.swt.watchdog.ticks(), SWT_TO_DEFAULT)
 

--- a/cm2350/tests/test_mpc5674_timebase.py
+++ b/cm2350/tests/test_mpc5674_timebase.py
@@ -1,10 +1,5 @@
-import time
-
 import envi.bits as e_bits
-import envi.archs.ppc.spr as eaps
 import envi.archs.ppc.regs as eapr
-
-from .. import emutimers
 
 from .helpers import MPC5674_Test
 
@@ -17,7 +12,7 @@ INSTR_SPR_SHIFT = 11
 
 # Because of how we are measuring elapsed time in the tests this should be 
 # extremely accurate
-TIMING_ACCURACY = 0.0001
+TIMING_ACCURACY = 0.002
 
 
 class MPC5674_SPRHOOKS_Test(MPC5674_Test):
@@ -83,27 +78,18 @@ class MPC5674_SPRHOOKS_Test(MPC5674_Test):
         # Ensure TBL and TBR are 0 by default
         self.assertEqual(self.tb_read(), (0, 0))
 
-        freq = self.emu.getSystemFreq()
-
-        # Get the start emulated time
-        now = self.emu.systime()
-
         # Start the PPC core timebase
         self.emu.enableTimebase()
 
-        # Sleep for 1 second so some time passes in the system
-        time.sleep(1.0)
+        # Sleep for 0.1 second of emulated time
+        self.emu.sleep(0.1)
 
         # Stop all emulator time (also pauses the PPC timebase)
         self.emu.halt_time()
 
         tbl, tbu = self.tb_read()
 
-        # Get the amount of emulated time that has elapsed
-        elapsed = self.emu.systime() - now
-
-        # Determine the expected upper range based on the elapsed emulated time.
-        expected_tbl = int(elapsed * freq)
+        expected_tbl = int(0.1 * self.emu.getSystemFreq())
         margin = TIMING_ACCURACY * expected_tbl
 
         self.assert_timer_within_range(tbl, expected_tbl, margin)
@@ -125,26 +111,19 @@ class MPC5674_SPRHOOKS_Test(MPC5674_Test):
         # Ensure TBL and TBR are 0 by default
         self.assertEqual(self.tb_read(), (0, 0))
 
-        freq = self.emu.getSystemFreq()
-
-        # Get the start emulated time
-        now = self.emu.systime()
-
         # Start the PPC core timebase
         self.emu.enableTimebase()
 
-        time.sleep(1.0)
+        # Sleep for 0.1 second of emulated time
+        self.emu.sleep(0.1)
 
         # Stop all emulator time (also pauses the PPC timebase)
         self.emu.halt_time()
 
         tbl, tbu = self.tb_read()
 
-        # Get the amount of emulated time that has elapsed
-        elapsed = self.emu.systime() - now
-
         # Determine the expected upper range based on the elapsed emulated time.
-        expected_tbl = int(elapsed * freq)
+        expected_tbl = int(0.1 * self.emu.getSystemFreq())
         margin = TIMING_ACCURACY * expected_tbl
 
         self.assert_timer_within_range(tbl, expected_tbl, margin)
@@ -162,21 +141,15 @@ class MPC5674_SPRHOOKS_Test(MPC5674_Test):
         self.assertEqual(self.tb_read(), (0, 0))
         self.assertEqual(self.emu.getTimebase(), 0)
 
-        # Get the start emulated time
-        now = self.emu.systime()
-
-        # Start the timebase again sleep another second
+        # Start the timebase again sleep another 0.1 emulated seconds
         self.emu.resume_time()
-        time.sleep(1.0)
+        self.emu.sleep(0.1)
         self.emu.halt_time()
 
         tbl2, tbu2 = self.tb_read()
 
-        # Get the amount of emulated time that has elapsed
-        elapsed = self.emu.systime() - now
-
         # Accuracy margin should be the same as before
-        expected_tbl = int(elapsed * freq)
+        expected_tbl = int(0.1 * self.emu.getSystemFreq())
         self.assert_timer_within_range(tbl2, expected_tbl, margin)
 
         # Not enough time has passed for TBU to have a non-zero value.
@@ -201,19 +174,15 @@ class MPC5674_SPRHOOKS_Test(MPC5674_Test):
         self.assertEqual(self.tb_read(), (tb_offset, 0))
         self.assertEqual(self.emu.getTimebase(), tb_offset)
 
-        # Get the start emulated time
-        now = self.emu.systime()
-
         # Resume and run for about 0.1 seconds
         self.emu.resume_time()
-        time.sleep(0.1)
+        self.emu.sleep(0.1)
         self.emu.halt_time()
 
         tbl, tbu = self.tb_read()
 
         # Get the amount of emulated time that has elapsed
-        elapsed = self.emu.systime() - now
-        expected_tb = int(elapsed * self.emu.getSystemFreq()) + tb_offset
+        expected_tb = int(0.1 * self.emu.getSystemFreq()) + tb_offset
         tb = (tbu << 32) | tbl
 
         # TBU should now be 1
@@ -249,14 +218,12 @@ class MPC5674_SPRHOOKS_Test(MPC5674_Test):
 
         # Resume and run for about 0.1 seconds
         self.emu.resume_time()
-        time.sleep(0.1)
+        self.emu.sleep(0.1)
         self.emu.halt_time()
 
         tbl, tbu = self.tb_read()
 
-        # Get the amount of emulated time that has elapsed
-        elapsed = self.emu.systime() - now
-        expected_tb = int(elapsed * self.emu.getSystemFreq()) + tb_offset
+        expected_tb = int(0.1 * self.emu.getSystemFreq()) + tb_offset
         tb = (tbu << 32) | tbl
 
         # TBU should have overflowed back to 0


### PR DESCRIPTION
Made emulator timing flexible to support different methods of measuring time in the emulator. At the moment the emulator time is fixed at the tick-based time which should provide more accurate timing for the emulator execution.

The scaled emulation timing has the advantage that it removes the decision about when timers should expire from the primary thread of execution, because all time in the emulator is based on a fixed scaling factor off of the host OS's system time. The downside is that time will progress at a steady pace regardless of how efficient or inefficient the emulation of specific instructions or peripheral actions are. This can lead to timer events that should happen at deterministic points of code execution (like the decrementer exception or the ASIC watchdog expiring) happening much earlier than they are supposed to happen.

This PR implements tracking time by counting each instruction as a single tick. This isn't 100% accurate because there may be pipeline stalls depending on the sequence of loads, stores, or other instructions that take multiple cycles to execute. But without trying to emulate the full execution pipeline and caching this seemed like the way to make timing more accurate with the smallest impact to performance.

Unfortunately it looks like this change cuts performance almost in half given a brief run of the CM2350 firmware during start up:

python version: 
```
[ins] In [2]: import sys;sys.version
Out[2]: '3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0]'
```
"accurate timing" (`EmuTimeCore`)
```
since start: 3773501 instructions in 62.097 secs: 60768.233 ops/sec
```

"scaled timing" (`ScaledEmuTimeCore`)
```
since start: 2659691 instructions in 24.875 secs: 106921.954 ops/sec
```